### PR TITLE
Make SItoA compile with Arnold 5.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ With contributions by:
 - Frederic Servant
 - Jules Stevenson
 
-After open-sourcing, development has been continued by:
+After open-sourcing, development has continued by:
 
 - Jens Lindgren
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ under an Apache 2.0 open source license.
 #### Requirements
 
 * Softimage 2015 SP1
-* Arnold 5.0.2.4 or newer
+* Arnold 5.1.0.0 or newer
 * Python 2.6 or newer
 * Visual Studio 2012 (Windows)
 * GCC 4.2.4 (Linux)
@@ -365,6 +365,10 @@ With contributions by:
 - Holger Schoenberger
 - Frederic Servant
 - Jules Stevenson
+
+After open-sourcing, development has been continued by:
+
+- Jens Lindgren
 
 Special thanks to all the users who passionately provided feedback, production
 assets, bug reports and suggested features during those years.

--- a/plugins/sitoa/common/Tools.cpp
+++ b/plugins/sitoa/common/Tools.cpp
@@ -1216,9 +1216,6 @@ CString GetRenderCodeDesc(int in_errorCode)
       case AI_ABORT:
          desc = L"render aborted";
          break;
-      case AI_ERROR_WRONG_OUTPUT:
-         desc = L"can't open output file";
-         break;
       case AI_ERROR_NO_CAMERA:
          desc = L"camera not defined";
          break;
@@ -1231,20 +1228,14 @@ CString GetRenderCodeDesc(int in_errorCode)
       case AI_ERROR_RENDER_REGION:
          desc = L"invalid render region";
          break;
-      case AI_ERROR_OUTPUT_EXISTS:
-         desc = L"output file already exists";
-         break;
-      case AI_ERROR_OPENING_FILE:
-         desc = L"can't open file";
-         break;
       case AI_INTERRUPT:
          desc = L"render interrupted by user";
          break;
-      case AI_ERROR_UNRENDERABLE_SCENEGRAPH:
-         desc = L"unrenderable scenegraph";
-         break;
       case AI_ERROR_NO_OUTPUTS:
          desc = L"no rendering outputs";
+         break;
+      case AI_ERROR_UNAVAILABLE_DEVICE:
+         desc = L"Cannot create GPU context.";
          break;
       case AI_ERROR:
          desc = L"generic error";

--- a/plugins/sitoa/renderer/RenderInstance.cpp
+++ b/plugins/sitoa/renderer/RenderInstance.cpp
@@ -1035,7 +1035,7 @@ void CRenderInstance::SetRenderStatus(const eRenderStatus in_status)
 }
 
 
-int CRenderInstance::DoRender(const int in_mode)
+int CRenderInstance::DoRender(const AtRenderMode in_mode)
 {
    SetRenderStatus(eRenderStatus_Started);
    int result = AiRender(in_mode);

--- a/plugins/sitoa/renderer/RenderInstance.h
+++ b/plugins/sitoa/renderer/RenderInstance.h
@@ -266,6 +266,6 @@ private:
    // class for the auto shader definition
    CShaderDefSet      m_shaderDefSet;
 
-   int DoRender(const int in_mode = AI_RENDER_MODE_CAMERA);
+   int DoRender(const AtRenderMode in_mode = AI_RENDER_MODE_CAMERA);
 };
 

--- a/plugins/sitoa/version.cpp
+++ b/plugins/sitoa/version.cpp
@@ -13,9 +13,9 @@ See the License for the specific language governing permissions and limitations 
 
 #include <xsi_utils.h>
 
-#define SITOA_MAJOR_VERSION_NUM    4
-#define SITOA_MINOR_VERSION_NUM    1
-#define SITOA_FIX_VERSION          L"0"
+#define SITOA_MAJOR_VERSION_NUM    5
+#define SITOA_MINOR_VERSION_NUM    0
+#define SITOA_FIX_VERSION          L"0-alpha"
 
 
 CString GetSItoAVersion(bool in_addPlatform)


### PR DESCRIPTION
Just bare minimum changes to make it compile.
We have to look at changing to the new render control API later.
I also bumped SItoA version to 5.0.0-alpha and credited myself :)