### PR TITLE
New Arnold 5.1.0 shaders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,12 +19,6 @@ custom.py
 dist
 build
 
-# VS and VS Code
-.vs
-.vscode/*
-*.user
-*.code-workspace
-
 # Eclipse
 .settings
 .*project

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,12 @@ custom.py
 dist
 build
 
+# VS and VS Code
+.vs
+.vscode/*
+*.user
+*.code-workspace
+
 # Eclipse
 .settings
 .*project

--- a/plugins/helpers/ArnoldMenu.js
+++ b/plugins/helpers/ArnoldMenu.js
@@ -112,9 +112,18 @@ function AddShader_Execute(in_shaderName, in_connectionPoint, in_collection, in_
          {
             DeleteObj(shader);      
             shader = CreateShaderFromProgID(in_shaderName, xsiObj.material, null);
-            var closure = CreateShaderFromProgID("Arnold.closure.1.0", xsiObj.material, null);
-            SIConnectShaderToCnxPoint(shader, closure + ".closure", false);
-            SIConnectShaderToCnxPoint(closure, xsiObj.material + ".surface", false);
+            // we only want to add a closure shader when it's needed
+            // closures have 20 as OutputType value so we test for that
+            if (shader.OutputType == 20)
+            {
+               var closure = CreateShaderFromProgID("Arnold.closure.1.0", xsiObj.material, null);
+               SIConnectShaderToCnxPoint(shader, closure + ".closure", false);
+               SIConnectShaderToCnxPoint(closure, xsiObj.material + ".surface", false);
+            }
+            else
+            {
+               SIConnectShaderToCnxPoint(shader, xsiObj.material + ".surface", false);
+            }
          }
       }
    }

--- a/plugins/helpers/ArnoldMenu.js
+++ b/plugins/helpers/ArnoldMenu.js
@@ -242,6 +242,7 @@ function AddShadersSubMenu(in_menu)
 {
    in_menu.AddCallbackItem("Standard Surface",  "OnShadersMenu");
    in_menu.AddCallbackItem("Standard Hair",     "OnShadersMenu");
+   in_menu.AddCallbackItem("Toon",              "OnShadersMenu");
    in_menu.AddCallbackItem("Utility",           "OnShadersMenu");
    in_menu.AddSeparatorItem();
    in_menu.AddCallbackItem("Camera Projection", "OnShadersMenu");
@@ -434,6 +435,9 @@ function OnShadersMenu(in_ctxt)
          break;
       case "Standard Hair":
          SITOA_AddShader("Arnold.standard_hair.1.0", "surface");
+         break;
+      case "Toon":
+         SITOA_AddShader("Arnold.toon.1.0", "surface");
          break;
       case "Utility":
          SITOA_AddShader("Arnold.utility.1.0", null);

--- a/plugins/helpers/ArnoldScenePreferences.js
+++ b/plugins/helpers/ArnoldScenePreferences.js
@@ -160,8 +160,9 @@ function CreateRenderChannels()
    aov_array.push({ name: "shadow",                type: siRenderChannelColorType });
    aov_array.push({ name: "shadow_diff",           type: siRenderChannelColorType });
    aov_array.push({ name: "shadow_mask",           type: siRenderChannelColorType });
-   aov_array.push({ name: "indirect_diffuse",      type: siRenderChannelColorType });
-   aov_array.push({ name: "indirect_specular",     type: siRenderChannelColorType });
+   // toon
+   aov_array.push({ name: "highlight",             type: siRenderChannelColorType });
+   aov_array.push({ name: "rim_light",             type: siRenderChannelColorType });
 
    var aov_name, aov_type;
 	for (var i = 0; i < aov_array.length; i++) 

--- a/plugins/helpers/ArnoldShaderDef.js
+++ b/plugins/helpers/ArnoldShaderDef.js
@@ -111,6 +111,7 @@ function XSILoadPlugin( in_reg )
    in_reg.RegisterShader("switch_rgba", 1, 0);
    in_reg.RegisterShader("switch_shader", 1, 0);
    in_reg.RegisterShader("thin_film", 1, 0);
+   in_reg.RegisterShader("toon", 1, 0);
    in_reg.RegisterShader("trace_set", 1, 0);
    in_reg.RegisterShader("trigo", 1, 0);
    in_reg.RegisterShader("triplanar", 1, 0);
@@ -317,6 +318,8 @@ function Arnold_switch_shader_1_0_DefineInfo(in_ctxt) { return true; }
 function Arnold_switch_shader_1_0_Define(in_ctxt) { return true; }
 function Arnold_thin_film_1_0_DefineInfo(in_ctxt) { return true; }
 function Arnold_thin_film_1_0_Define(in_ctxt) { return true; }
+function Arnold_toon_1_0_DefineInfo(in_ctxt) { return true; }
+function Arnold_toon_1_0_Define(in_ctxt) { return true; }
 function Arnold_trace_set_1_0_DefineInfo(in_ctxt) { return true; }
 function Arnold_trace_set_1_0_Define(in_ctxt) { return true; }
 function Arnold_trigo_1_0_DefineInfo(in_ctxt) { return true; }

--- a/plugins/helpers/ArnoldShaderDef.js
+++ b/plugins/helpers/ArnoldShaderDef.js
@@ -62,6 +62,7 @@ function XSILoadPlugin( in_reg )
    in_reg.RegisterShader("image", 1, 0);
    in_reg.RegisterShader("is_finite", 1, 0);
    in_reg.RegisterShader("lambert", 1, 0);
+   in_reg.RegisterShader("layer_float", 1, 0);
    in_reg.RegisterShader("length", 1, 0);
    in_reg.RegisterShader("log", 1, 0);
    in_reg.RegisterShader("matte", 1, 0);
@@ -216,6 +217,8 @@ function Arnold_is_finite_1_0_DefineInfo(in_ctxt) { return true; }
 function Arnold_is_finite_1_0_Define(in_ctxt) { return true; }
 function Arnold_lambert_1_0_DefineInfo(in_ctxt) { return true; }
 function Arnold_lambert_1_0_Define(in_ctxt) { return true; }
+function Arnold_layer_float_1_0_DefineInfo(in_ctxt) { return true; }
+function Arnold_layer_float_1_0_Define(in_ctxt) { return true; }
 function Arnold_length_1_0_DefineInfo(in_ctxt) { return true; }
 function Arnold_length_1_0_Define(in_ctxt) { return true; }
 function Arnold_log_1_0_DefineInfo(in_ctxt) { return true; }

--- a/plugins/helpers/ArnoldShaderDef.js
+++ b/plugins/helpers/ArnoldShaderDef.js
@@ -63,6 +63,8 @@ function XSILoadPlugin( in_reg )
    in_reg.RegisterShader("is_finite", 1, 0);
    in_reg.RegisterShader("lambert", 1, 0);
    in_reg.RegisterShader("layer_float", 1, 0);
+   in_reg.RegisterShader("layer_rgba", 1, 0);
+   in_reg.RegisterShader("layer_shader", 1, 0);
    in_reg.RegisterShader("length", 1, 0);
    in_reg.RegisterShader("log", 1, 0);
    in_reg.RegisterShader("matte", 1, 0);
@@ -219,6 +221,10 @@ function Arnold_lambert_1_0_DefineInfo(in_ctxt) { return true; }
 function Arnold_lambert_1_0_Define(in_ctxt) { return true; }
 function Arnold_layer_float_1_0_DefineInfo(in_ctxt) { return true; }
 function Arnold_layer_float_1_0_Define(in_ctxt) { return true; }
+function Arnold_layer_rgba_1_0_DefineInfo(in_ctxt) { return true; }
+function Arnold_layer_rgba_1_0_Define(in_ctxt) { return true; }
+function Arnold_layer_shader_1_0_DefineInfo(in_ctxt) { return true; }
+function Arnold_layer_shader_1_0_Define(in_ctxt) { return true; }
 function Arnold_length_1_0_DefineInfo(in_ctxt) { return true; }
 function Arnold_length_1_0_Define(in_ctxt) { return true; }
 function Arnold_log_1_0_DefineInfo(in_ctxt) { return true; }

--- a/plugins/sitoa/renderer/RendererOptions.cpp
+++ b/plugins/sitoa/renderer/RendererOptions.cpp
@@ -800,8 +800,10 @@ SITOA_CALLBACK CommonRenderOptions_DefineLayout(CRef& in_ctxt)
       filters.Add(L"blackman_harris"); filters.Add(L"blackman_harris");
       filters.Add(L"box");        filters.Add(L"box");
       filters.Add(L"catmull-rom");filters.Add(L"catrom");
+      filters.Add(L"contour");filters.Add(L"contour");
       filters.Add(L"gaussian");   filters.Add(L"gaussian");
       filters.Add(L"mitchell-netravali"); filters.Add(L"mitnet");
+      filters.Add(L"sinc"); filters.Add(L"sinc");
       filters.Add(L"triangle");   filters.Add(L"triangle");       
       filters.Add(L"variance");   filters.Add(L"variance");
       layout.AddEnumControl(L"output_filter", filters, L"Type", siControlCombo);    
@@ -1279,7 +1281,8 @@ void SamplingTabLogic(CustomProperty &in_cp)
    CString filter = ParAcc_GetValue(in_cp, L"output_filter", DBL_MAX).GetAsText();
 
    bool enableWidth = filter.IsEqualNoCase(L"gaussian") || filter.IsEqualNoCase(L"triangle") ||
-                      filter.IsEqualNoCase(L"variance") || filter.IsEqualNoCase(L"blackman_harris");
+                      filter.IsEqualNoCase(L"variance") || filter.IsEqualNoCase(L"blackman_harris") ||
+                      filter.IsEqualNoCase(L"contour") || filter.IsEqualNoCase(L"sinc");
 
    ParAcc_GetParameter(in_cp, L"output_filter_width").PutCapabilityFlag(siReadOnly, !enableWidth);
 

--- a/shaders/metadata/arnold_shaders.mtd
+++ b/shaders/metadata/arnold_shaders.mtd
@@ -2984,6 +2984,274 @@ softmax FLOAT 3
 soft.label STRING "Internal IOR"
 
 ##############################################################################
+[node toon]
+soft.category STRING "Surface"
+soft.order STRING "BeginGroup Edge enable edge_color edge_tonemap edge_opacity edge_width_scale "
+    "BeginGroup Edge_Detection id_difference shader_difference mask_color uv_threshold angle_threshold normal_type EndGroup "
+    "BeginGroup Advanced_Edge_Control priority ignore_throughput EndGroup "
+"EndGroup "
+"BeginGroup Silhouette enable_silhouette silhouette_color silhouette_tonemap silhouette_opacity silhouette_width_scale EndGroup "
+"BeginGroup Base base base_color base_tonemap EndGroup "
+"BeginGroup Specular specular specular_color specular_roughness specular_anisotropy specular_rotation specular_tonemap EndGroup "
+"BeginGroup Stylized_Highlight lights highlight_color highlight_size EndGroup "
+"BeginGroup Rim_Lighting rim_light rim_light_color rim_light_width EndGroup "
+"BeginGroup Transmission transmission transmission_color transmission_roughness transmission_anisotropy transmission_rotation IOR EndGroup "
+"BeginGroup Emission emission emission_color EndGroup "
+"BeginGroup Geometry normal tangent bump_mode EndGroup "
+"BeginGroup AOVs aov_highlight aov_rim_light EndGroup "
+"BeginGroup Advanced indirect_diffuse indirect_specular energy_conserving EndGroup"
+
+# Edge
+
+[attr enable]
+desc STRING "When turned off, the edge detection is disabled (enabled by default)."
+soft.label STRING "Edge (requires contour filter)"
+
+[attr edge_color]
+desc STRING "The color of the toon edge. The line style can be controlled with a texture here."
+
+[attr edge_tonemap]
+desc STRING "Connect a ramp node here to change the Edge Color based on the shading result of the Base."
+
+[attr edge_opacity]
+desc STRING "Controls the transparency of the Edge."
+min FLOAT 0
+max FLOAT 1
+
+[attr edge_width_scale]
+desc STRING "The maximum width of contour lines is determined by the Width parameter of the Contour Filter. The actual width is the multiplication of it and this parameter. The line style can be controlled by combining this with a texture."
+soft.label STRING "Width Scaling"
+min FLOAT 0
+max FLOAT 1
+
+[attr id_difference]
+desc STRING "If enabled, edge detection uses the difference of IDs from neighboring pixels."
+soft.label STRING "ID Difference"
+
+[attr shader_difference]
+desc STRING "Detects the difference of shaders of neighboring samples. This is useful when multiple shaders are assigned to a single polymesh, for example."
+
+[attr mask_color]
+desc STRING "The edge is detected when the mask color of neighboring pixels is different. The Mask Color is assumed to have a texture connected to draw an arbitrary shape by detecting color differences."
+
+[attr uv_threshold]
+desc STRING "If enabled, edge detection uses the difference of UVs from neighboring pixels."
+soft.label STRING "UV Threshold"
+min FLOAT 0
+softmin FLOAT 0
+softmax FLOAT 1
+
+[attr angle_threshold]
+desc STRING "When less than 180, the Edge detection uses the difference of the angle between neighboring pixels."
+min FLOAT 0
+max FLOAT 180
+
+[attr normal_type]
+desc STRING "The normal used in the Edge detection. Choose from: Shading Normal, Smoothed Normal, and Geometric Normal."
+
+[attr priority]
+desc STRING "Changes the sorting priority of the Edge."
+softmin INT 0
+softmax INT 10
+
+[attr ignore_throughput]
+desc STRING "By default, the contour color is affected by ray throughput. If a specific color is required for a reflected/refracted object, enable this and use a ray_switch shader."
+
+# Silhouette
+
+[attr enable_silhouette]
+desc STRING ""
+soft.label STRING "Enable"
+
+[attr silhouette_color]
+desc STRING "The color of the silhouette edge. The line style can be controlled with a texture here."
+soft.label STRING "Color"
+
+[attr silhouette_tonemap]
+desc STRING "Connect a ramp node here to change the Silhouette Color based on the shading result of the Base."
+soft.label STRING "Tonemap"
+
+[attr silhouette_opacity]
+desc STRING "Controls the transparency of the Silhouette."
+soft.label STRING "Opacity"
+min FLOAT 0
+max FLOAT 1
+
+[attr silhouette_width_scale]
+desc STRING "The maximum width of silhouette contour lines is determined by the Width parameter of the Contour Filter. The actual width is the multiplication of it and this parameter. The line style can be controlled by combining this with a texture."
+soft.label STRING "Width Scaling"
+min FLOAT 0
+max FLOAT 1
+
+[attr base]
+desc STRING "The base color weight (default is 0.8)."
+soft.label STRING "Weight"
+min FLOAT 0
+max FLOAT 1
+
+[attr base_color]
+desc STRING ""
+soft.label STRING "Color"
+
+[attr base_tonemap]
+desc STRING "Connect a ramp node here to create a cell look (regarded as a tone map)."
+soft.label STRING "Tonemap"
+
+# Specular
+
+[attr specular]
+desc STRING "The specular weight. Influences the brightness of the specular highlight."
+soft.label STRING "Weight"
+min FLOAT 0
+max FLOAT 1
+
+[attr specular_color]
+desc STRING "The color the specular reflection will be modulated with. Use this color to 'tint' the specular highlight."
+soft.label STRING "Color"
+
+[attr specular_roughness]
+desc STRING "Controls the glossiness of the specular reflections."
+soft.label STRING "Roughness"
+min FLOAT 0
+max FLOAT 1
+
+[attr specular_anisotropy]
+desc STRING "Anisotropy reflects and transmits light with a directional bias and causes materials to appear rougher or glossier in certain directions. The default value for Anisotropy is 0, which means isotropic. As you move the control towards 1.0, the surface is made more anisotropic in the U axis."
+soft.label STRING "Anisotropy"
+min FLOAT 0
+max FLOAT 1
+
+[attr specular_rotation]
+desc STRING "The rotation value changes the orientation of the anisotropic reflectance in UV space. At 0.0, there is no rotation, while at 1.0 the effect is rotated by 180 degrees."
+soft.label STRING "Rotation"
+softmin FLOAT 0
+softmax FLOAT 1
+
+[attr specular_tonemap]
+desc STRING "Connect a ramp node here to create a cell look (regarded as a tone map)."
+soft.label STRING "Tonemap"
+
+# Stylized highlight
+
+[attr lights]
+desc STRING "Specify the name of the key light to be used for the stylized highlight. You can specify multiple lights using a semicolon-delimited string as lightShape1;lightShape2. The supported light types are Distant, Point, Spot, and Photometric."
+
+[attr highlight_color]
+desc STRING "An arbitrary texture (or RGB type node) can be used to create a stylized highlight on an object. If nothing is connected, the stylized highlight is disabled."
+soft.label STRING "Color"
+
+[attr highlight_size]
+desc STRING "The size of the stylized highlight."
+soft.label STRING "Size"
+min FLOAT 0
+max FLOAT 1
+
+# Rim lighting
+
+[attr rim_light]
+desc STRING "Specify the name of the light to be used here. Rim lighting is affected by the shadow of this light. The supported light types are: Distant, Point, Spot, and Photometric."
+soft.label STRING "Light"
+
+[attr rim_light_color]
+desc STRING "The color of the rim light. Connect a ramp here to get a rim lighting effect."
+soft.label STRING "Color"
+
+[attr rim_light_width]
+desc STRING "The size of the stylized highlight."
+soft.label STRING "Width"
+min FLOAT 0
+max FLOAT 1
+
+# Transmission
+
+[attr transmission]
+desc STRING "Transmission allows light to scatter through the surface, for materials such as glass or water."
+soft.label STRING "Weight"
+min FLOAT 0
+max FLOAT 1
+
+[attr transmission_color]
+desc STRING "This filters the refraction according to the distance traveled by the refracted ray. The longer light travels inside a mesh, the more it is affected by the Transmission Color."
+soft.label STRING "Color"
+
+[attr transmission_roughness]
+desc STRING "Adds some additional blurriness of a refraction computed with an isotropic microfacet BTDF. The range goes from 0 (no roughness) to 1."
+soft.label STRING "Roughness"
+min FLOAT 0
+max FLOAT 1
+
+[attr transmission_anisotropy]
+desc STRING "The directional bias, or anisotropy, of the scattering. The default value of zero gives isotropic scattering so that light is scattered evenly in all directions. Positive values bias the scattering effect forwards, in the direction of the light, while negative values bias the scattering backward, toward the light."
+soft.label STRING "Anisotropy"
+min FLOAT 0
+max FLOAT 1
+
+[attr transmission_rotation]
+desc STRING "The rotation value changes the orientation of the anisotropic reflectance in UV space. At 0.0, there is no rotation, while at 1.0 the effect is rotated by 180 degrees."
+soft.label STRING "Rotation"
+softmin FLOAT 0
+softmax FLOAT 1
+
+[attr IOR]
+desc STRING "The IOR parameter (Index of Refraction) defines the material's Fresnel reflectivity and is by default the angular function used."
+soft.label STRING "IOR"
+min FLOAT 0
+softmin FLOAT 0
+softmax FLOAT 3
+
+# Emission
+
+[attr emission]
+desc STRING "Controls the amount of emitted light. It can create noise, especially if the source of indirect illumination is very small (e.g. light bulb geometry)."
+soft.label STRING "Weight"
+min FLOAT 0
+softmin FLOAT 0
+softmax FLOAT 1
+
+[attr emission_color]
+desc STRING "The emitted light color."
+soft.label STRING "Color"
+
+# Geometry
+
+[attr normal]
+desc STRING "Connect a Normal map here (usually exported from Mudbox or ZBrush)."
+soft.inspectable BOOL false
+
+[attr tangent]
+desc STRING "The tangent map. Together with the shading normal, it defines the tangent coordinate system that the input vector applies to."
+soft.inspectable BOOL false
+
+[attr bump_mode]
+desc STRING "Choose the component(s) affected by bump: diffuse, specular, or both."
+soft.label STRING "Bump Mapping Mode"
+
+# AOVs
+
+[attr aov_highlight]
+desc STRING "Stylized highlight AOV."
+soft.label STRING "Highlight"
+
+[attr aov_rim_light]
+desc STRING "Rim light AOV."
+soft.label STRING "Rim Light"
+
+# Advanced
+
+[attr indirect_diffuse]
+desc STRING "The amount of diffuse light received from indirect sources only."
+min FLOAT 0
+max FLOAT 1
+
+[attr indirect_specular]
+desc STRING "The amount of specularity received from indirect sources only. Values other than 1.0 will cause the materials to not preserve energy, and global illumination may not converge."
+min FLOAT 0
+max FLOAT 1
+
+[attr energy_conserving]
+desc STRING "The Toon shader is energy conserving by default. If this is disabled, the Toon shader simply adds Base, Specular, and Transmission. Care should be taken when disabling this option as it will affect indirect illumination with the Toon shader."
+
+##############################################################################
 [node trace_set]
 soft.category STRING "Utility"
 

--- a/shaders/metadata/arnold_shaders.mtd
+++ b/shaders/metadata/arnold_shaders.mtd
@@ -1215,6 +1215,321 @@ softmin FLOAT 0
 softmax FLOAT 1
 
 ##############################################################################
+[node layer_rgba]
+soft.category STRING "Utility"
+soft.order STRING "BeginGroup Layer_1 enable1 name1 input1 operation1 mix1 alpha_operation1 EndGroup "
+"BeginGroup Layer_2 enable2 name2 input2 operation2 mix2 alpha_operation2 EndGroup "
+"BeginGroup Layer_3 enable3 name3 input3 operation3 mix3 alpha_operation3 EndGroup "
+"BeginGroup Layer_4 enable4 name4 input4 operation4 mix4 alpha_operation4 EndGroup "
+"BeginGroup Layer_5 enable5 name5 input5 operation5 mix5 alpha_operation5 EndGroup "
+"BeginGroup Layer_6 enable6 name6 input6 operation6 mix6 alpha_operation6 EndGroup "
+"BeginGroup Layer_7 enable7 name7 input7 operation7 mix7 alpha_operation7 EndGroup "
+"BeginGroup Layer_8 enable8 name8 input8 operation8 mix8 alpha_operation8 EndGroup"
+
+[attr enable1]
+soft.label STRING "Enable"
+
+[attr name1]
+soft.label STRING "Name"
+
+[attr input1]
+soft.label STRING "Input"
+
+[attr mix1]
+soft.label STRING "Mix"
+min FLOAT 0
+softmin FLOAT 0
+softmax FLOAT 1
+
+[attr operation1]
+soft.label STRING "Operation"
+
+[attr alpha_operation1]
+soft.label STRING "Alpha Operation"
+
+[attr enable2]
+soft.label STRING "Enable"
+
+[attr name2]
+soft.label STRING "Name"
+
+[attr input2]
+soft.label STRING "Input"
+
+[attr mix2]
+soft.label STRING "Mix"
+min FLOAT 0
+softmin FLOAT 0
+softmax FLOAT 1
+
+[attr operation2]
+soft.label STRING "Operation"
+
+[attr alpha_operation2]
+soft.label STRING "Alpha Operation"
+
+[attr enable3]
+soft.label STRING "Enable"
+
+[attr name3]
+soft.label STRING "Name"
+
+[attr input3]
+soft.label STRING "Input"
+
+[attr mix3]
+soft.label STRING "Mix"
+min FLOAT 0
+softmin FLOAT 0
+softmax FLOAT 1
+
+[attr operation3]
+soft.label STRING "Operation"
+
+[attr alpha_operation3]
+soft.label STRING "Alpha Operation"
+
+[attr enable4]
+soft.label STRING "Enable"
+
+[attr name4]
+soft.label STRING "Name"
+
+[attr input4]
+soft.label STRING "Input"
+
+[attr mix4]
+soft.label STRING "Mix"
+min FLOAT 0
+softmin FLOAT 0
+softmax FLOAT 1
+
+[attr operation4]
+soft.label STRING "Operation"
+
+[attr alpha_operation4]
+soft.label STRING "Alpha Operation"
+
+[attr enable5]
+soft.label STRING "Enable"
+
+[attr name5]
+soft.label STRING "Name"
+
+[attr input5]
+soft.label STRING "Input"
+
+[attr mix5]
+soft.label STRING "Mix"
+min FLOAT 0
+softmin FLOAT 0
+softmax FLOAT 1
+
+[attr operation5]
+soft.label STRING "Operation"
+
+[attr alpha_operation5]
+soft.label STRING "Alpha Operation"
+
+[attr enable6]
+soft.label STRING "Enable"
+
+[attr name6]
+soft.label STRING "Name"
+
+[attr input6]
+soft.label STRING "Input"
+
+[attr mix6]
+soft.label STRING "Mix"
+min FLOAT 0
+softmin FLOAT 0
+softmax FLOAT 1
+
+[attr operation6]
+soft.label STRING "Operation"
+
+[attr alpha_operation6]
+soft.label STRING "Alpha Operation"
+
+[attr enable7]
+soft.label STRING "Enable"
+
+[attr name7]
+soft.label STRING "Name"
+
+[attr input7]
+soft.label STRING "Input"
+
+[attr mix7]
+soft.label STRING "Mix"
+min FLOAT 0
+softmin FLOAT 0
+softmax FLOAT 1
+
+[attr operation7]
+soft.label STRING "Operation"
+
+[attr alpha_operation7]
+soft.label STRING "Alpha Operation"
+
+[attr enable8]
+soft.label STRING "Enable"
+
+[attr name8]
+soft.label STRING "Name"
+
+[attr input8]
+soft.label STRING "Input"
+
+[attr mix8]
+soft.label STRING "Mix"
+min FLOAT 0
+softmin FLOAT 0
+softmax FLOAT 1
+
+[attr operation8]
+soft.label STRING "Operation"
+
+[attr alpha_operation8]
+soft.label STRING "Alpha Operation"
+
+[attr clamp]
+soft.label STRING "Clamp Result"
+
+##############################################################################
+[node layer_shader]
+soft.category STRING "Utility"
+soft.order STRING "BeginGroup Layer_1 enable1 name1 input1 mix1 EndGroup "
+"BeginGroup Layer_2 enable2 name2 input2 mix2 EndGroup "
+"BeginGroup Layer_3 enable3 name3 input3 mix3 EndGroup "
+"BeginGroup Layer_4 enable4 name4 input4 mix4 EndGroup "
+"BeginGroup Layer_5 enable5 name5 input5 mix5 EndGroup "
+"BeginGroup Layer_6 enable6 name6 input6 mix6 EndGroup "
+"BeginGroup Layer_7 enable7 name7 input7 mix7 EndGroup "
+"BeginGroup Layer_8 enable8 name8 input8 mix8 EndGroup"
+
+[attr enable1]
+soft.label STRING "Enable"
+
+[attr name1]
+soft.label STRING "Name"
+
+[attr input1]
+soft.label STRING "Input"
+
+[attr mix1]
+soft.label STRING "Mix"
+min FLOAT 0
+softmin FLOAT 0
+softmax FLOAT 1
+
+[attr enable2]
+soft.label STRING "Enable"
+
+[attr name2]
+soft.label STRING "Name"
+
+[attr input2]
+soft.label STRING "Input"
+
+[attr mix2]
+soft.label STRING "Mix"
+min FLOAT 0
+softmin FLOAT 0
+softmax FLOAT 1
+
+[attr enable3]
+soft.label STRING "Enable"
+
+[attr name3]
+soft.label STRING "Name"
+
+[attr input3]
+soft.label STRING "Input"
+
+[attr mix3]
+soft.label STRING "Mix"
+min FLOAT 0
+softmin FLOAT 0
+softmax FLOAT 1
+
+[attr enable4]
+soft.label STRING "Enable"
+
+[attr name4]
+soft.label STRING "Name"
+
+[attr input4]
+soft.label STRING "Input"
+
+[attr mix4]
+soft.label STRING "Mix"
+min FLOAT 0
+softmin FLOAT 0
+softmax FLOAT 1
+
+[attr enable5]
+soft.label STRING "Enable"
+
+[attr name5]
+soft.label STRING "Name"
+
+[attr input5]
+soft.label STRING "Input"
+
+[attr mix5]
+soft.label STRING "Mix"
+min FLOAT 0
+softmin FLOAT 0
+softmax FLOAT 1
+
+[attr enable6]
+soft.label STRING "Enable"
+
+[attr name6]
+soft.label STRING "Name"
+
+[attr input6]
+soft.label STRING "Input"
+
+[attr mix6]
+soft.label STRING "Mix"
+min FLOAT 0
+softmin FLOAT 0
+softmax FLOAT 1
+
+[attr enable7]
+soft.label STRING "Enable"
+
+[attr name7]
+soft.label STRING "Name"
+
+[attr input7]
+soft.label STRING "Input"
+
+[attr mix7]
+soft.label STRING "Mix"
+min FLOAT 0
+softmin FLOAT 0
+softmax FLOAT 1
+
+[attr enable8]
+soft.label STRING "Enable"
+
+[attr name8]
+soft.label STRING "Name"
+
+[attr input8]
+soft.label STRING "Input"
+
+[attr mix8]
+soft.label STRING "Mix"
+min FLOAT 0
+softmin FLOAT 0
+softmax FLOAT 1
+
+##############################################################################
 [node length]
 soft.category STRING "Math"
 

--- a/shaders/metadata/arnold_shaders.mtd
+++ b/shaders/metadata/arnold_shaders.mtd
@@ -1067,6 +1067,154 @@ desc STRING "Controls how opaque the shader is."
 desc STRING "If linked, the normal to use."
 
 ##############################################################################
+[node layer_float]
+soft.category STRING "Utility"
+soft.order STRING "BeginGroup Layer_1 enable1 name1 input1 mix1 EndGroup "
+"BeginGroup Layer_2 enable2 name2 input2 mix2 EndGroup "
+"BeginGroup Layer_3 enable3 name3 input3 mix3 EndGroup "
+"BeginGroup Layer_4 enable4 name4 input4 mix4 EndGroup "
+"BeginGroup Layer_5 enable5 name5 input5 mix5 EndGroup "
+"BeginGroup Layer_6 enable6 name6 input6 mix6 EndGroup "
+"BeginGroup Layer_7 enable7 name7 input7 mix7 EndGroup "
+"BeginGroup Layer_8 enable8 name8 input8 mix8 EndGroup"
+
+[attr enable1]
+soft.label STRING "Enable"
+
+[attr name1]
+soft.label STRING "Name"
+
+[attr input1]
+soft.label STRING "Input"
+softmin FLOAT 0
+softmax FLOAT 1
+
+[attr mix1]
+soft.label STRING "Mix"
+min FLOAT 0
+softmin FLOAT 0
+softmax FLOAT 1
+
+[attr enable2]
+soft.label STRING "Enable"
+
+[attr name2]
+soft.label STRING "Name"
+
+[attr input2]
+soft.label STRING "Input"
+softmin FLOAT 0
+softmax FLOAT 1
+
+[attr mix2]
+soft.label STRING "Mix"
+min FLOAT 0
+softmin FLOAT 0
+softmax FLOAT 1
+
+[attr enable3]
+soft.label STRING "Enable"
+
+[attr name3]
+soft.label STRING "Name"
+
+[attr input3]
+soft.label STRING "Input"
+softmin FLOAT 0
+softmax FLOAT 1
+
+[attr mix3]
+soft.label STRING "Mix"
+min FLOAT 0
+softmin FLOAT 0
+softmax FLOAT 1
+
+[attr enable4]
+soft.label STRING "Enable"
+
+[attr name4]
+soft.label STRING "Name"
+
+[attr input4]
+soft.label STRING "Input"
+softmin FLOAT 0
+softmax FLOAT 1
+
+[attr mix4]
+soft.label STRING "Mix"
+min FLOAT 0
+softmin FLOAT 0
+softmax FLOAT 1
+
+[attr enable5]
+soft.label STRING "Enable"
+
+[attr name5]
+soft.label STRING "Name"
+
+[attr input5]
+soft.label STRING "Input"
+softmin FLOAT 0
+softmax FLOAT 1
+
+[attr mix5]
+soft.label STRING "Mix"
+min FLOAT 0
+softmin FLOAT 0
+softmax FLOAT 1
+
+[attr enable6]
+soft.label STRING "Enable"
+
+[attr name6]
+soft.label STRING "Name"
+
+[attr input6]
+soft.label STRING "Input"
+softmin FLOAT 0
+softmax FLOAT 1
+
+[attr mix6]
+soft.label STRING "Mix"
+min FLOAT 0
+softmin FLOAT 0
+softmax FLOAT 1
+
+[attr enable7]
+soft.label STRING "Enable"
+
+[attr name7]
+soft.label STRING "Name"
+
+[attr input7]
+soft.label STRING "Input"
+softmin FLOAT 0
+softmax FLOAT 1
+
+[attr mix7]
+soft.label STRING "Mix"
+min FLOAT 0
+softmin FLOAT 0
+softmax FLOAT 1
+
+[attr enable8]
+soft.label STRING "Enable"
+
+[attr name8]
+soft.label STRING "Name"
+
+[attr input8]
+soft.label STRING "Input"
+softmin FLOAT 0
+softmax FLOAT 1
+
+[attr mix8]
+soft.label STRING "Mix"
+min FLOAT 0
+softmin FLOAT 0
+softmax FLOAT 1
+
+##############################################################################
 [node length]
 soft.category STRING "Math"
 


### PR DESCRIPTION
Added the following new shaders:
- `layer_float`
- `layer_rgba`
- `layer_shader`
- `toon`

For `toon` to work properly I also added the new `contour` filter. While I was there I noticed that the `sinc` filter was missing so I added that as well.

Two new aovs for the toon shader is also added.

toon is outputting color instead of a closure so it couldn't be added to objects directly with AddShader() so I updated that function to handle non closure shaders as well.
