### PR TITLE
Arnold 5.2 main features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,12 @@ custom.py
 dist
 build
 
+# VS and VS Code
+.vs
+.vscode/*
+*.user
+*.code-workspace
+
 # Eclipse
 .settings
 .*project

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ under an Apache 2.0 open source license.
 #### Requirements
 
 * Softimage 2015 SP1
-* Arnold 5.1.0.0 or newer
+* Arnold 5.2.0.0 or newer
 * Python 2.6 or newer
 * Visual Studio 2012 (Windows)
 * GCC 4.2.4 (Linux)
@@ -365,9 +365,6 @@ With contributions by:
 - Holger Schoenberger
 - Frederic Servant
 - Jules Stevenson
-
-After open-sourcing, development has continued by:
-
 - Jens Lindgren
 
 Special thanks to all the users who passionately provided feedback, production

--- a/plugins/helpers/ArnoldMenu.js
+++ b/plugins/helpers/ArnoldMenu.js
@@ -249,6 +249,7 @@ function ArnoldShaders_Init(io_Context)
 
 function AddShadersSubMenu(in_menu)
 {
+   in_menu.AddCallbackItem("Car Paint",         "OnShadersMenu");
    in_menu.AddCallbackItem("Standard Surface",  "OnShadersMenu");
    in_menu.AddCallbackItem("Standard Hair",     "OnShadersMenu");
    in_menu.AddCallbackItem("Toon",              "OnShadersMenu");
@@ -439,6 +440,9 @@ function OnShadersMenu(in_ctxt)
    var item = in_ctxt.Source;
    switch (item.Name)
    {
+      case "Car Paint":
+         SITOA_AddShader("Arnold.car_paint.1.0", "surface");
+         break;
       case "Standard Surface":
          SITOA_AddShader("Arnold.standard_surface.1.0", "surface");
          break;

--- a/plugins/helpers/ArnoldProperties.js
+++ b/plugins/helpers/ArnoldProperties.js
@@ -479,6 +479,7 @@ function AddParamsShape(in_prop)
    in_prop.AddParameter2("export_pref",               siBool, false, null, null, null, null);
    in_prop.AddParameter2("subdiv_smooth_derivs",      siBool, false, null, null, null, null);
    in_prop.AddParameter2("sss_setname", siString, "", null, null, null, null, 0, siPersistable|siAnimatable);
+   in_prop.AddParameter2("toon_id", siString, "", null, null, null, null, 0, siPersistable|siAnimatable);
    in_prop.AddParameter2("trace_sets",  siString, "", null, null, null, null, 0, siPersistable|siAnimatable);
     //new per-object motion blur 
    in_prop.AddParameter2("motion_transform",           siBool,     true, null, null, null, null);
@@ -650,6 +651,11 @@ function arnold_parameters_DefineLayout(io_Context)
 
    xsiLayout.AddGroup("SSS Set Name", true, 50);
       item = xsiLayout.AddItem("sss_setname", "");
+      item.SetAttribute(siUINoLabel, true);
+   xsiLayout.EndGroup();
+
+   xsiLayout.AddGroup("Toon ID", true, 50);
+      item = xsiLayout.AddItem("toon_id", "");
       item.SetAttribute(siUINoLabel, true);
    xsiLayout.EndGroup();
 

--- a/plugins/helpers/ArnoldProperties.js
+++ b/plugins/helpers/ArnoldProperties.js
@@ -479,7 +479,7 @@ function AddParamsShape(in_prop)
    in_prop.AddParameter2("export_pref",               siBool, false, null, null, null, null);
    in_prop.AddParameter2("subdiv_smooth_derivs",      siBool, false, null, null, null, null);
    in_prop.AddParameter2("sss_setname", siString, "", null, null, null, null, 0, siPersistable|siAnimatable);
-   in_prop.AddParameter2("toon_id", siString, "", null, null, null, null, 0, siPersistable|siAnimatable);
+   in_prop.AddParameter2("toon_id",     siString, "", null, null, null, null, 0, siPersistable|siAnimatable);
    in_prop.AddParameter2("trace_sets",  siString, "", null, null, null, null, 0, siPersistable|siAnimatable);
     //new per-object motion blur 
    in_prop.AddParameter2("motion_transform",           siBool,     true, null, null, null, null);

--- a/plugins/helpers/ArnoldScenePreferences.js
+++ b/plugins/helpers/ArnoldScenePreferences.js
@@ -164,6 +164,10 @@ function CreateRenderChannels()
    // toon
    aov_array.push({ name: "highlight",             type: siRenderChannelColorType });
    aov_array.push({ name: "rim_light",             type: siRenderChannelColorType });
+   // cryptomatte
+   aov_array.push({ name: "crypto_asset",          type: siRenderChannelColorType });
+   aov_array.push({ name: "crypto_object",         type: siRenderChannelColorType });
+   aov_array.push({ name: "crypto_material",       type: siRenderChannelColorType });
 
    var aov_name, aov_type;
 	for (var i = 0; i < aov_array.length; i++) 

--- a/plugins/helpers/ArnoldScenePreferences.js
+++ b/plugins/helpers/ArnoldScenePreferences.js
@@ -155,6 +155,7 @@ function CreateRenderChannels()
    aov_array.push({ name: "volume_direct",         type: siRenderChannelColorType });
    aov_array.push({ name: "volume_indirect",       type: siRenderChannelColorType });
    aov_array.push({ name: "volume_opacity",        type: siRenderChannelColorType });
+   aov_array.push({ name: "volume_Z",              type: siRenderChannelGrayscaleType });
    aov_array.push({ name: "Z",                     type: siRenderChannelGrayscaleType });
    // shadow_matte shader
    aov_array.push({ name: "shadow",                type: siRenderChannelColorType });

--- a/plugins/helpers/ArnoldShaderDef.js
+++ b/plugins/helpers/ArnoldShaderDef.js
@@ -48,6 +48,7 @@ function XSILoadPlugin( in_reg )
    in_reg.RegisterShader("complex_ior", 1, 0);
    in_reg.RegisterShader("composite", 1, 0);
    in_reg.RegisterShader("cross", 1, 0);
+   in_reg.RegisterShader("cryptomatte", 1, 0);
    in_reg.RegisterShader("curvature", 1, 0);
    in_reg.RegisterShader("divide", 1, 0);
    in_reg.RegisterShader("dot", 1, 0);
@@ -197,6 +198,8 @@ function Arnold_composite_1_0_DefineInfo(in_ctxt) { return true; }
 function Arnold_composite_1_0_Define(in_ctxt) { return true; }
 function Arnold_cross_1_0_DefineInfo(in_ctxt) { return true; }
 function Arnold_cross_1_0_Define(in_ctxt) { return true; }
+function Arnold_cryptomatte_1_0_DefineInfo(in_ctxt) { return true; }
+function Arnold_cryptomatte_1_0_Define(in_ctxt) { return true; }
 function Arnold_curvature_1_0_DefineInfo(in_ctxt) { return true; }
 function Arnold_curvature_1_0_Define(in_ctxt) { return true; }
 function Arnold_divide_1_0_DefineInfo(in_ctxt) { return true; }

--- a/plugins/helpers/ArnoldShaderDef.js
+++ b/plugins/helpers/ArnoldShaderDef.js
@@ -27,6 +27,7 @@ function XSILoadPlugin( in_reg )
    in_reg.RegisterShader("aov_write_float", 1, 0);
    in_reg.RegisterShader("aov_write_int", 1, 0);
    in_reg.RegisterShader("aov_write_rgb", 1, 0);
+   in_reg.RegisterShader("aov_write_rgba", 1, 0);
    in_reg.RegisterShader("atan", 1, 0);
    in_reg.RegisterShader("atmosphere_volume", 1, 0);
    in_reg.RegisterShader("blackbody", 1, 0);
@@ -34,6 +35,7 @@ function XSILoadPlugin( in_reg )
    in_reg.RegisterShader("bump3d", 1, 0);
    in_reg.RegisterShader("cache", 1, 0);
    in_reg.RegisterShader("camera_projection", 1, 0);
+   in_reg.RegisterShader("car_paint", 1, 0);
    in_reg.RegisterShader("checkerboard", 1, 0);
    in_reg.RegisterShader("clamp", 1, 0);
    in_reg.RegisterShader("closure", 1, 0); // SItoA
@@ -150,6 +152,8 @@ function Arnold_aov_write_int_1_0_DefineInfo(in_ctxt) { return true; }
 function Arnold_aov_write_int_1_0_Define(in_ctxt) { return true; }
 function Arnold_aov_write_rgb_1_0_DefineInfo(in_ctxt) { return true; }
 function Arnold_aov_write_rgb_1_0_Define(in_ctxt) { return true; }
+function Arnold_aov_write_rgba_1_0_DefineInfo(in_ctxt) { return true; }
+function Arnold_aov_write_rgba_1_0_Define(in_ctxt) { return true; }
 function Arnold_atan_1_0_DefineInfo(in_ctxt) { return true; }
 function Arnold_atan_1_0_Define(in_ctxt) { return true; }
 function Arnold_atmosphere_volume_1_0_DefineInfo(in_ctxt) { return true; }
@@ -164,6 +168,8 @@ function Arnold_cache_1_0_DefineInfo(in_ctxt) { return true; }
 function Arnold_cache_1_0_Define(in_ctxt) { return true; }
 function Arnold_camera_projection_1_0_DefineInfo(in_ctxt) { return true; }
 function Arnold_camera_projection_1_0_Define(in_ctxt) { return true; }
+function Arnold_car_paint_1_0_DefineInfo(in_ctxt) { return true; }
+function Arnold_car_paint_1_0_Define(in_ctxt) { return true; }
 function Arnold_checkerboard_1_0_DefineInfo(in_ctxt) { return true; }
 function Arnold_checkerboard_1_0_Define(in_ctxt) { return true; }
 function Arnold_clamp_1_0_DefineInfo(in_ctxt) { return true; }

--- a/plugins/helpers/ArnoldShaderDef.js
+++ b/plugins/helpers/ArnoldShaderDef.js
@@ -36,6 +36,7 @@ function XSILoadPlugin( in_reg )
    in_reg.RegisterShader("cache", 1, 0);
    in_reg.RegisterShader("camera_projection", 1, 0);
    in_reg.RegisterShader("car_paint", 1, 0);
+   in_reg.RegisterShader("cell_noise", 1, 0);
    in_reg.RegisterShader("checkerboard", 1, 0);
    in_reg.RegisterShader("clamp", 1, 0);
    in_reg.RegisterShader("closure", 1, 0); // SItoA
@@ -170,6 +171,8 @@ function Arnold_camera_projection_1_0_DefineInfo(in_ctxt) { return true; }
 function Arnold_camera_projection_1_0_Define(in_ctxt) { return true; }
 function Arnold_car_paint_1_0_DefineInfo(in_ctxt) { return true; }
 function Arnold_car_paint_1_0_Define(in_ctxt) { return true; }
+function Arnold_cell_noise_1_0_DefineInfo(in_ctxt) { return true; }
+function Arnold_cell_noise_1_0_Define(in_ctxt) { return true; }
 function Arnold_checkerboard_1_0_DefineInfo(in_ctxt) { return true; }
 function Arnold_checkerboard_1_0_Define(in_ctxt) { return true; }
 function Arnold_clamp_1_0_DefineInfo(in_ctxt) { return true; }

--- a/plugins/helpers/ArnoldShaderDef.js
+++ b/plugins/helpers/ArnoldShaderDef.js
@@ -70,6 +70,8 @@ function XSILoadPlugin( in_reg )
    in_reg.RegisterShader("layer_shader", 1, 0);
    in_reg.RegisterShader("length", 1, 0);
    in_reg.RegisterShader("log", 1, 0);
+   in_reg.RegisterShader("matrix_multiply_vector", 1, 0);
+   in_reg.RegisterShader("matrix_transform", 1, 0);
    in_reg.RegisterShader("matte", 1, 0);
    in_reg.RegisterShader("max", 1, 0);
    in_reg.RegisterShader("min", 1, 0);
@@ -239,6 +241,10 @@ function Arnold_length_1_0_DefineInfo(in_ctxt) { return true; }
 function Arnold_length_1_0_Define(in_ctxt) { return true; }
 function Arnold_log_1_0_DefineInfo(in_ctxt) { return true; }
 function Arnold_log_1_0_Define(in_ctxt) { return true; }
+function Arnold_matrix_multiply_vector_1_0_DefineInfo(in_ctxt) { return true; }
+function Arnold_matrix_multiply_vector_1_0_Define(in_ctxt) { return true; }
+function Arnold_matrix_transform_1_0_DefineInfo(in_ctxt) { return true; }
+function Arnold_matrix_transform_1_0_Define(in_ctxt) { return true; }
 function Arnold_matte_1_0_DefineInfo(in_ctxt) { return true; }
 function Arnold_matte_1_0_Define(in_ctxt) { return true; }
 function Arnold_max_1_0_DefineInfo(in_ctxt) { return true; }

--- a/plugins/sitoa/loader/Options.cpp
+++ b/plugins/sitoa/loader/Options.cpp
@@ -591,8 +591,6 @@ void LoadOptionsParameters(AtNode* in_optionsNode, const Property &in_arnoldOpti
    // Set the maximum number of files open
    CNodeSetter::SetInt(in_optionsNode, "texture_max_open_files", GetRenderOptions()->m_texture_max_open_files);
    CNodeSetter::SetFloat(in_optionsNode, "texture_max_sharpen",    1.5f); // #1559
-   CNodeSetter::SetFloat(in_optionsNode, "texture_diffuse_blur",   GetRenderOptions()->m_texture_diffuse_blur);
-   CNodeSetter::SetFloat(in_optionsNode, "texture_specular_blur",    GetRenderOptions()->m_texture_specular_blur);
 
    CNodeSetter::SetBoolean(in_optionsNode, "texture_per_file_stats", GetRenderOptions()->m_texture_per_file_stats);
 

--- a/plugins/sitoa/loader/Properties.cpp
+++ b/plugins/sitoa/loader/Properties.cpp
@@ -336,6 +336,19 @@ void LoadArnoldParameters(AtNode* in_node, CParameterRefArray &in_paramsArray, d
          continue;
       }
 
+      if (!strcmp(charParamName, "toon_id"))
+      {
+         CString toonId = param.GetValue(); 
+         if (toonId.IsEmpty()) // Avoid exporting the toon_id if it is empty
+            continue;
+         if (!AiNodeLookUpUserParameter(in_node, "toon_id"))
+            AiNodeDeclare(in_node, "toon_id", "constant STRING");
+         if (AiNodeLookUpUserParameter(in_node, "toon_id"))
+            CNodeSetter::SetString(in_node, "toon_id", toonId.GetAsciiString());
+
+         continue;
+      }
+
       if (!strcmp(charParamName, "trace_sets")) // #783: Expose the trace sets string for shapes
       {
          CString traceSets = param.GetValue(); 

--- a/plugins/sitoa/renderer/RendererOptions.cpp
+++ b/plugins/sitoa/renderer/RendererOptions.cpp
@@ -167,8 +167,6 @@ void CRenderOptions::Read(const Property &in_cp)
    m_texture_accept_unmipped = (bool)ParAcc_GetValue(in_cp,  L"texture_accept_unmipped", DBL_MAX);
    m_texture_automip         = (bool)ParAcc_GetValue(in_cp,  L"texture_automip",         DBL_MAX);
    m_texture_filter          = (int)ParAcc_GetValue(in_cp,   L"texture_filter",          DBL_MAX);
-   m_texture_diffuse_blur    = (float)ParAcc_GetValue(in_cp, L"texture_diffuse_blur",    DBL_MAX);
-   m_texture_specular_blur   = (float)ParAcc_GetValue(in_cp, L"texture_specular_blur",   DBL_MAX);
    m_texture_accept_untiled  = (bool)ParAcc_GetValue(in_cp,  L"texture_accept_untiled",  DBL_MAX);
    m_enable_autotile         = (bool)ParAcc_GetValue(in_cp,  L"enable_autotile",         DBL_MAX);
    m_texture_autotile        = (int)ParAcc_GetValue(in_cp,   L"texture_autotile",        DBL_MAX);
@@ -428,8 +426,6 @@ SITOA_CALLBACK CommonRenderOptions_Define(CRef& in_ctxt)
    cpset.AddParameter(L"texture_accept_unmipped", CValue::siBool,   siPersistable, L"", L"", true, CValue(), CValue(), CValue(), CValue(), p);
    cpset.AddParameter(L"texture_automip",         CValue::siBool,   siPersistable, L"", L"", false, CValue(), CValue(), CValue(), CValue(), p);
    cpset.AddParameter(L"texture_filter",          CValue::siInt4,   siPersistable, L"", L"", AI_TEXTURE_SMART_BICUBIC, CValue(), CValue(), CValue(), CValue(), p);
-   cpset.AddParameter(L"texture_diffuse_blur",    CValue::siDouble, siPersistable, L"", L"", 0.03125, 0, 1, 0, 0.1, p);
-   cpset.AddParameter(L"texture_specular_blur",   CValue::siDouble, siPersistable, L"", L"", 0.0, 0, 1, 0, 0.1, p);
    cpset.AddParameter(L"texture_accept_untiled",  CValue::siBool,   siPersistable, L"", L"", true, CValue(), CValue(), CValue(), CValue(), p);
    cpset.AddParameter(L"enable_autotile",         CValue::siBool,   siPersistable, L"", L"", false, CValue(), CValue(), CValue(), CValue(), p);
    cpset.AddParameter(L"texture_autotile",        CValue::siInt4,   siPersistable, L"", L"", 64, 16, 1024, 16, 512, p);
@@ -909,12 +905,6 @@ SITOA_CALLBACK CommonRenderOptions_DefineLayout(CRef& in_ctxt)
       item = layout.AddEnumControl(L"texture_filter", textFilters, L"Filter", siControlCombo);
       item.PutAttribute(siUILabelMinPixels, 195);
       item.PutAttribute(siUILabelPercentage, 90);
-      item = layout.AddItem(L"texture_diffuse_blur", L"Diffuse Blur");
-      item.PutAttribute(siUILabelMinPixels, 195);
-      item.PutAttribute(siUILabelPercentage, 30);
-      item = layout.AddItem(L"texture_specular_blur", L"Specular Blur");
-      item.PutAttribute(siUILabelMinPixels, 195);
-      item.PutAttribute(siUILabelPercentage, 30);
    layout.EndGroup();
    layout.AddGroup(L"Tiling", true, 0);
       layout.AddItem(L"texture_accept_untiled", L"Accept Untiled Textures");

--- a/plugins/sitoa/renderer/RendererOptions.h
+++ b/plugins/sitoa/renderer/RendererOptions.h
@@ -152,8 +152,6 @@ public:
    bool  m_texture_accept_unmipped;
    bool  m_texture_automip;
    int   m_texture_filter;
-   float m_texture_diffuse_blur;
-   float m_texture_specular_blur;
    bool  m_texture_accept_untiled;
    bool  m_enable_autotile;
    int   m_texture_autotile;
@@ -317,8 +315,6 @@ public:
       m_texture_accept_unmipped(true),
       m_texture_automip(false),
       m_texture_filter(AI_TEXTURE_SMART_BICUBIC),
-      m_texture_diffuse_blur(0.03125f),
-      m_texture_specular_blur(0.0f), // note that Arnold's default is 0.015625
       m_texture_accept_untiled(true),
       m_enable_autotile(false),
       m_texture_autotile(64),

--- a/plugins/sitoa/version.cpp
+++ b/plugins/sitoa/version.cpp
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and limitations 
 #include <xsi_utils.h>
 
 #define SITOA_MAJOR_VERSION_NUM    5
-#define SITOA_MINOR_VERSION_NUM    1
-#define SITOA_FIX_VERSION          L"0-alpha"
+#define SITOA_MINOR_VERSION_NUM    2
+#define SITOA_FIX_VERSION          L"0"
 
 
 CString GetSItoAVersion(bool in_addPlatform)

--- a/shaders/metadata/arnold_shaders.mtd
+++ b/shaders/metadata/arnold_shaders.mtd
@@ -558,15 +558,27 @@ soft.label STRING "UV Set"
 [node clamp]
 soft.category STRING "Utility"
 
+[attr input]
+desc STRING "Input shader to apply the clamp to."
+
+[attr mode]
+desc STRING "Can be set to Scalar or RGB. When set to RGB the input result is clamped between Min Color and Max Color."
+
 [attr min]
 desc STRING "The minumum value that the input will be clamped to."
 softmin FLOAT 0
-softmax FLOAT 1
+softmax FLOAT 10
 
 [attr max]
 desc STRING "The maximum value that the input will be clamped to."
 softmin FLOAT 0
-softmax FLOAT 1
+softmax FLOAT 10
+
+[attr min_color]
+desc STRING "The minimum value for the color channels to be used in the output."
+
+[attr max_color]
+desc STRING "The maximum value for the color channels to be used in the output."
 
 # SItoA specific
 ##############################################################################
@@ -2263,28 +2275,51 @@ desc STRING "Produce a cheaper to compute, monochromatic noise."
 [node range]
 soft.category STRING "Math"
 
+[attr input]
+desc STRING "Input shader to apply the range to."
+
 [attr input_min]
 desc STRING "The minimum value of the input range."
 softmin FLOAT 0
-softmax FLOAT 3
+softmax FLOAT 10
 
 [attr input_max]
 desc STRING "The maximum value of the input range."
 softmin FLOAT 0
-softmax FLOAT 3
+softmax FLOAT 10
 
 [attr output_min]
 desc STRING "The minimum value of the output range. The Input Min will be mapped to this value."
 softmin FLOAT 0
-softmax FLOAT 3
+softmax FLOAT 10
 
 [attr output_max]
 desc STRING "The maximum value of the input range. The Input Max will be mapped to this value."
 softmin FLOAT 0
-softmax FLOAT 3
+softmax FLOAT 10
 
 [attr smoothstep]
 desc STRING "Interpolates the output range smoothly between the max and min output values. The returned value is clamped between these values."
+
+[attr contrast]
+desc STRING "Scales values around the Contrast Pivot."
+softmin FLOAT 0
+softmax FLOAT 10
+
+[attr contrast_pivot]
+desc STRING "The origin of the contrast scaling. The default is 0.18 which is the average perceptual mid-gray."
+softmin FLOAT 0
+softmax FLOAT 1
+
+[attr bias]
+desc STRING "Push or pull values by altering the slope at the beginning of the range. Bias values below 0.5 decrease the slope and lower values overall.  Above 0.5, the slope is higher, and the value grow's more quickly. A value of 0.5 has no effect."
+softmin FLOAT 0
+softmax FLOAT 1
+
+[attr gain]
+desc STRING "Increase or decrease the slope of the mid-range values. Gain values below 0.5 increase the contrast whereas values above 0.5 flatten the mid-range values. A value of 0.5 has no effect."
+softmin FLOAT 0
+softmax FLOAT 10
 
 ##############################################################################
 [node ray_switch_rgba]

--- a/shaders/metadata/arnold_shaders.mtd
+++ b/shaders/metadata/arnold_shaders.mtd
@@ -1808,6 +1808,14 @@ desc STRING "Input to calcute logarithm of."
 desc STRING "Base for use in logarithm calculation."
 
 ##############################################################################
+[node matrix_multiply_vector]
+soft.category STRING "Math"
+
+##############################################################################
+[node matrix_transform]
+soft.category STRING "Math"
+
+##############################################################################
 [node matte]
 soft.category STRING "Surface"
 

--- a/shaders/metadata/arnold_shaders.mtd
+++ b/shaders/metadata/arnold_shaders.mtd
@@ -961,6 +961,54 @@ desc STRING "Second vector to use in cross product computation."
 soft.label STRING "Input 2"
 
 ##############################################################################
+[node cryptomatte]
+soft.category STRING "AOV"
+
+[attr sidecar_manifests]
+desc STRING "Sets whether Cryptomatte should write the manifest to a sidecar .json file instead of the EXR header."
+
+[attr cryptomatte_depth]
+desc STRING "Set the cryptomatte depth (number of cryptomatte AOVs)"
+softmin INT 0
+softmax INT 10
+
+[attr strip_obj_namespaces]
+desc STRING "Strip namespaces from object names"
+
+[attr strip_mat_namespaces]
+desc STRING "Strip namespaces from material names"
+
+[attr user_crypto_aov_0]
+desc STRING "AOV name for user Cryptomatte 0"
+
+[attr user_crypto_src_0]
+desc STRING "Source user data name for user Cryptomatte 0"
+
+[attr user_crypto_aov_1]
+desc STRING "AOV name for user Cryptomatte 1"
+
+[attr user_crypto_src_1]
+desc STRING "Source user data name for user Cryptomatte 1"
+
+[attr user_crypto_aov_2]
+desc STRING "AOV name for user Cryptomatte 2"
+
+[attr user_crypto_src_2]
+desc STRING "Source user data name for user Cryptomatte 2"
+
+[attr user_crypto_aov_3]
+desc STRING "AOV name for user Cryptomatte 3"
+
+[attr user_crypto_src_3]
+desc STRING "Source user data name for user Cryptomatte 3"
+
+[attr aov_crypto_asset]
+
+[attr aov_crypto_object]
+
+[attr aov_crypto_material]
+
+##############################################################################
 [node curvature]
 soft.category STRING "Utility"
 

--- a/shaders/metadata/arnold_shaders.mtd
+++ b/shaders/metadata/arnold_shaders.mtd
@@ -3306,7 +3306,7 @@ soft.label STRING "Internal IOR"
 soft.category STRING "Surface"
 soft.order STRING "BeginGroup Edge enable edge_color edge_tonemap edge_opacity edge_width_scale "
     "BeginGroup Edge_Detection id_difference shader_difference mask_color uv_threshold angle_threshold normal_type EndGroup "
-    "BeginGroup Advanced_Edge_Control priority ignore_throughput EndGroup "
+    "BeginGroup Advanced_Edge_Control priority ignore_throughput user_id EndGroup "
 "EndGroup "
 "BeginGroup Silhouette enable_silhouette silhouette_color silhouette_tonemap silhouette_opacity silhouette_width_scale EndGroup "
 "BeginGroup Base base base_color base_tonemap EndGroup "
@@ -3374,6 +3374,10 @@ softmax INT 10
 
 [attr ignore_throughput]
 desc STRING "By default, the contour color is affected by ray throughput. If a specific color is required for a reflected/refracted object, enable this and use a ray_switch shader."
+
+[attr user_id]
+desc STRING "Edge detection can be controlled using a STRING type user data called Toon ID."
+soft.label STRING "Use Toon ID"
 
 # Silhouette
 

--- a/shaders/metadata/arnold_shaders.mtd
+++ b/shaders/metadata/arnold_shaders.mtd
@@ -446,6 +446,67 @@ soft.label STRING "Normal"
 soft.inspectable BOOL false
 
 ##############################################################################
+[node cell_noise]
+soft.category STRING "Texture"
+
+[attr pattern]
+desc STRING "Pattern"
+
+[attr additive]
+desc STRING "If Additive is true, all noise patterns are simply added. If this is false, the largest value is selected."
+
+[attr octaves]
+desc STRING "The number of octaves over which the noise function is calculated."
+softmin INT 1
+softmax INT 8
+
+[attr randomness]
+desc STRING "If randomness is greater than 0, feature point locations are jittered. If the value gets closer to 0, patterns have a more regular, axis aligned look."
+min FLOAT 0
+softmin FLOAT 0
+softmax FLOAT 1
+
+[attr lacunarity]
+desc STRING "Controls the average size of gaps in the texture pattern produced."
+min FLOAT 0.0001
+softmin FLOAT 1
+softmax FLOAT 5
+
+[attr amplitude]
+desc STRING "Controls the amplitude, or range, of the output. Normally the output has values between 0 and 1; the amplitude control multiplies this."
+softmin FLOAT 0
+softmax FLOAT 1
+
+[attr scale]
+desc STRING "Controls the scale of the noise function in x, y, and z directions."
+
+[attr offset]
+desc STRING "Offset the noise in x, y, or z directions."
+
+[attr coord_space]
+desc STRING "Specifies the coordinate space to use."
+
+[attr pref_name]
+desc STRING "Specify the name of the reference position user-data array."
+
+[attr P]
+desc STRING "Input coordinates of the 4D fractal noise function."
+
+[attr time]
+desc STRING "The pattern of noise smoothly varies over time."
+
+[attr color]
+desc STRING "Multiply a specified color to the resulting noise pattern."
+
+[attr palette]
+desc STRING "The color of each Voronoi cell is randomly picked from the connected node. An arbitrary RGB node including image and ramp can be connected here. Note that this is different from simple texturing using UV."
+
+[attr density]
+desc STRING "This parameter can be used to create flake noise by decimating some cells. This only works with cell1/cell2 for now."
+softmin FLOAT 0
+softmax FLOAT 1
+
+##############################################################################
 [node checkerboard]
 soft.category STRING "Texture"
 

--- a/shaders/metadata/arnold_shaders.mtd
+++ b/shaders/metadata/arnold_shaders.mtd
@@ -2624,6 +2624,7 @@ soft.order STRING "BeginGroup Base base base_color diffuse_roughness metalness E
 "BeginGroup Transmission transmission transmission_color transmission_depth transmission_scatter transmission_scatter_anisotropy transmission_dispersion transmission_extra_roughness transmit_aovs EndGroup "
 "BeginGroup Subsurface subsurface subsurface_color subsurface_radius subsurface_scale subsurface_type subsurface_anisotropy EndGroup "
 "BeginGroup Coat coat coat_color coat_roughness coat_IOR coat_normal coat_affect_color coat_affect_roughness EndGroup "
+"BeginGroup Sheen sheen sheen_color sheen_roughness EndGroup "
 "BeginGroup Thin_Film thin_film_thickness thin_film_IOR EndGroup "
 "BeginGroup Emission emission emission_color EndGroup "
 "BeginGroup Geometry thin_walled opacity normal tangent EndGroup "
@@ -2825,6 +2826,22 @@ max FLOAT 1
 [attr coat_affect_roughness]
 desc STRING "Affect Roughness."
 soft.label STRING "Affect Roughness"
+min FLOAT 0
+max FLOAT 1
+
+[attr sheen]
+desc STRING "Sheen Weight"
+soft.label STRING "Weight"
+min FLOAT 0
+max FLOAT 1
+
+[attr sheen_color]
+desc STRING "Sheen Color"
+soft.label STRING "Color"
+
+[attr sheen_roughness]
+desc STRING "Sheen Roughness"
+soft.label STRING "Roughness"
 min FLOAT 0
 max FLOAT 1
 


### PR DESCRIPTION
A lot of stuff in this one...
First some .gitignore stuff for newer versions of Visual Studio (and Code).

I must have messed something up with the commits for Arnold 5.1. I fixed that now:
- car_paint and aov_write_rgba was missing shaderdefs
- add car_paint to Material menu
<br>

For Arnold 5.2 I bumped SItoA to 5.2.0 and changed the following:
- sheen added to standard_surface
- toon_id added to ArnoldParameters for use with new user_id (Use Toon ID) in toon shader
- new shader cell_noise
- new shaders matric_multiply_vector and matrix_transform
- updated clamp shader
- updated range shader
- new volume_Z AOV
- cryptomatte (shaderdef and AOVs pre created)
- removed texture blur options

It passes the testsuite so with this we can close #16 