### PR TITLE
Fix/closure shader inspect

### DIFF
--- a/plugins/sitoa/loader/ShaderDef.cpp
+++ b/plugins/sitoa/loader/ShaderDef.cpp
@@ -745,9 +745,10 @@ void CShaderDefShader::Layout()
       // github issue #33
       // for closure connector node whenever it's inspected show the shader connected to it
       layout.PutLogic(
-         L"function OnInit() {"
-         L"var src = PPG.closure.Source;"
-         L"if (src != null) InspectObj(src.Parent)};"
+         L"function OnInit() {\n"
+         L"   var src = PPG.closure.Source;"
+         L"   if (src != null) InspectObj(src.Parent);\n"
+         L"}"
          );
    }
 }

--- a/plugins/sitoa/loader/ShaderDef.cpp
+++ b/plugins/sitoa/loader/ShaderDef.cpp
@@ -736,7 +736,20 @@ void CShaderDefShader::Layout()
    }
    // unfortunately the following does not work (in the case the definition already exists)
    else // if there is no specific desc metadata, set the help to the shader page
-      layout.PutAttribute(siUIHelpFile, m_has_desc ? m_desc : SITOA_SHADERS_URL);      
+      layout.PutAttribute(siUIHelpFile, m_has_desc ? m_desc : SITOA_SHADERS_URL);
+
+   // setup ppg logic
+   layout.PutLanguage(L"JScript");
+   if (m_name == L"closure") 
+   {
+      // github issue #33
+      // for closure connector node whenever it's inspected show the shader connected to it
+      layout.PutLogic(
+         L"function OnInit() {"
+         L"var src = PPG.closure.Source;"
+         L"if (src != null) InspectObj(src.Parent)};"
+         );
+   }
 }
 
 

--- a/plugins/sitoa/loader/ShaderDef.cpp
+++ b/plugins/sitoa/loader/ShaderDef.cpp
@@ -745,10 +745,11 @@ void CShaderDefShader::Layout()
       // github issue #33
       // for closure connector node whenever it's inspected show the shader connected to it
       layout.PutLogic(
-         L"function OnInit() {\n"
-         L"   var src = PPG.closure.Source;"
+         L"function OnInit()\n"
+         L"{\n"
+         L"   var src = PPG.closure.Source;\n"
          L"   if (src != null) InspectObj(src.Parent);\n"
-         L"}"
+         L"}\n"
          );
    }
 }


### PR DESCRIPTION
This fix makes it so whenever the closure shader property page is inspected it forwards the inspection to the node connected to its input closure port. Since the closure shader has no gui and acts as a passthrough anyway this makes it easier to access the relevant node for the user.