### PR TITLE
Color Managers

### DIFF
--- a/plugins/helpers/ArnoldMenu.js
+++ b/plugins/helpers/ArnoldMenu.js
@@ -586,7 +586,8 @@ function About()
                           "Eric Mootz",
                           "Holger Schoenberger",
                           "Frederic Servant",
-                          "Jules Stevenson"
+                          "Jules Stevenson",
+                          "Jens Lindgren"
                           );
                          
    var layout = prop.PPGLayout;

--- a/plugins/sitoa/loader/Loader.cpp
+++ b/plugins/sitoa/loader/Loader.cpp
@@ -104,7 +104,7 @@ CStatus LoadScene(const Property &in_arnoldOptions, const CString& in_renderType
    // Compute the node mask
    // With a temporary Checking until it is completelly instaurated 
    // in all production scenes (for backward compatibility). Initializating to true
-   int output_options         = AI_NODE_OPTIONS;
+   int output_options         = AI_NODE_OPTIONS + AI_NODE_COLOR_MANAGER;
    int output_drivers_filters = AI_NODE_DRIVER + AI_NODE_FILTER;
    int output_geometry        = AI_NODE_SHAPE;
    int output_cameras         = AI_NODE_CAMERA;
@@ -114,7 +114,7 @@ CStatus LoadScene(const Property &in_arnoldOptions, const CString& in_renderType
    CPathString outputAssDir, assOutputName;
    bool useTranslation;
 
-   output_options  = toRender || GetRenderOptions()->m_output_options ? AI_NODE_OPTIONS: 0;
+   output_options  = toRender || GetRenderOptions()->m_output_options ? AI_NODE_OPTIONS + AI_NODE_COLOR_MANAGER: 0;
    output_drivers_filters = toRender || GetRenderOptions()->m_output_drivers_filters ? AI_NODE_DRIVER + AI_NODE_FILTER : 0;
    output_geometry = toRender || GetRenderOptions()->m_output_geometry  ? AI_NODE_SHAPE : 0;
    output_cameras  = toRender || GetRenderOptions()->m_output_cameras ? AI_NODE_CAMERA : 0;
@@ -246,7 +246,7 @@ CStatus LoadScene(const Property &in_arnoldOptions, const CString& in_renderType
          // and for the same reason deny filters and drivers
          output_drivers_filters = 0;
       }
-      else if (output_options == AI_NODE_OPTIONS)
+      else if (output_options != 0)
       {
          AiMsgDebug("[sitoa] Loading Options");
          status = LoadOptions(in_arnoldOptions, iframe);

--- a/plugins/sitoa/loader/Loader.cpp
+++ b/plugins/sitoa/loader/Loader.cpp
@@ -246,7 +246,7 @@ CStatus LoadScene(const Property &in_arnoldOptions, const CString& in_renderType
          // and for the same reason deny filters and drivers
          output_drivers_filters = 0;
       }
-      else if (output_options != 0)
+      else if ((output_options & AI_NODE_OPTIONS) == AI_NODE_OPTIONS)
       {
          AiMsgDebug("[sitoa] Loading Options");
          status = LoadOptions(in_arnoldOptions, iframe);

--- a/plugins/sitoa/loader/Options.cpp
+++ b/plugins/sitoa/loader/Options.cpp
@@ -224,8 +224,8 @@ bool LoadColorManager(AtNode* in_optionsNode, double in_frame)
             for (int i=0; i<8; i++) {
                chromaticitySample = atof(ocioChromaticitiesStrings[i].GetAsciiString());
 
-               // if a sample is 0.0 and is not green x (ACES uses 0.0 as green x) then issue a warning
-               if (chromaticitySample == 0.0f && i != 2)
+               // if a sample is 0.0 and is not green or blue x (ACES uses 0.0 as green x) then issue a warning
+               if (chromaticitySample == 0.0f && i != 2 && i != 4)
                   GetMessageQueue()->LogMsg(L"[sitoa] OCIO Chromaticity sample " + CString(i) + L" is 0.0", siWarningMsg);
                AiArraySetFlt(ocioChromaticities, i, chromaticitySample);
             }

--- a/plugins/sitoa/loader/Options.cpp
+++ b/plugins/sitoa/loader/Options.cpp
@@ -192,6 +192,40 @@ bool LoadFilters()
 }
 
 
+// Load the color manager
+//
+// @param in_optionsNode     the Arnold options node
+// @param in_frame           the frame time
+//
+// @return true if the color manager was well created, else false
+//
+bool LoadColorManager(AtNode* in_optionsNode, double in_frame)
+{
+   CString colorManager = GetRenderOptions()->m_color_manager;
+   if (colorManager == L"color_manager_ocio")
+   {
+      AtNode* ocioNode = AiNode("color_manager_ocio");
+      if (!ocioNode)
+            return false;
+      CNodeUtilities().SetName(ocioNode, "sitoa_color_manager_ocio");
+
+      CNodeSetter::SetString(ocioNode, "config",                GetRenderOptions()->m_ocio_config.GetAsciiString());
+      CNodeSetter::SetString(ocioNode, "color_space_narrow",    GetRenderOptions()->m_ocio_color_space_narrow.GetAsciiString());
+      CNodeSetter::SetString(ocioNode, "color_space_linear",    GetRenderOptions()->m_ocio_color_space_linear.GetAsciiString());
+      //AtArray* ocioChromaticities = AiArray(8, 1, AI_TYPE_FLOAT,
+      //0.713f, 0.293f,
+      //0.165f, 0.830f,
+      //0.128f, 0.044f,
+      //0.32168f, 0.33767f
+      //);
+      //AiNodeSetArray(ocioNode, "linear_chromaticities", ocioChromaticities);
+
+      CNodeSetter::SetPointer(in_optionsNode, "color_manager", ocioNode);
+   }
+   return true;
+}
+
+
 // class used to store the layers associated with a driver
 //
 class CDeepExrLayersDrivers
@@ -646,6 +680,10 @@ CStatus LoadOptions(const Property& in_arnoldOptions, double in_frame, bool in_f
 
    // load rendering options
    LoadOptionsParameters(optionsNode, in_arnoldOptions, in_frame);
+
+   // load color manager
+   if (!LoadColorManager(optionsNode, in_frame))
+      return CStatus::Fail;
 
    if (!in_flythrough)
    {

--- a/plugins/sitoa/loader/Options.cpp
+++ b/plugins/sitoa/loader/Options.cpp
@@ -207,7 +207,7 @@ bool LoadColorManager(AtNode* in_optionsNode, double in_frame)
    {
       AtNode* ocioNode = AiNode("color_manager_ocio");
       if (!ocioNode)
-            return false;
+         return false;
       CNodeUtilities().SetName(ocioNode, "sitoa_color_manager_ocio");
 
       CNodeSetter::SetString(ocioNode, "config",             GetRenderOptions()->m_ocio_config.GetAsciiString());
@@ -691,9 +691,10 @@ CStatus LoadOptions(const Property& in_arnoldOptions, double in_frame, bool in_f
    LoadOptionsParameters(optionsNode, in_arnoldOptions, in_frame);
 
    // load color manager
-   if (!LoadColorManager(optionsNode, in_frame))
+   if (!LoadColorManager(optionsNode, in_frame)) {
       GetMessageQueue()->LogMsg(L"[sitoa] Failed to create a Color Manager.", siWarningMsg);
       return CStatus::Abort;
+   }
 
    if (!in_flythrough)
    {

--- a/plugins/sitoa/loader/Options.cpp
+++ b/plugins/sitoa/loader/Options.cpp
@@ -220,13 +220,19 @@ bool LoadColorManager(AtNode* in_optionsNode, double in_frame)
          CStringArray ocioChromaticitiesStrings = ocioChromaticitiesString.Split(L" ");
          if (ocioChromaticitiesStrings.GetCount() == 8) {
             AtArray* ocioChromaticities = AiArrayAllocate(8, 1, AI_TYPE_FLOAT);
+            float chromaticitySample;
             for (int i=0; i<8; i++) {
-               AiArraySetFlt(ocioChromaticities, i, (float)atof(ocioChromaticitiesStrings[i].GetAsciiString()));
+               chromaticitySample = atof(ocioChromaticitiesStrings[i].GetAsciiString());
+
+               // if a sample is 0.0 and is not green x (ACES uses 0.0 as green x) then issue a warning
+               if (chromaticitySample == 0.0f && i != 2)
+                  GetMessageQueue()->LogMsg(L"[sitoa] OCIO Chromaticity sample " + CString(i) + L" is 0.0", siWarningMsg);
+               AiArraySetFlt(ocioChromaticities, i, chromaticitySample);
             }
             AiNodeSetArray(ocioNode, "linear_chromaticities", ocioChromaticities);
          }
          else {
-            GetMessageQueue()->LogMsg(L"[sitoa] OCIO Chromaticities could not be parsed: " + CString(ocioChromaticitiesString), siWarningMsg);
+            GetMessageQueue()->LogMsg(L"[sitoa] OCIO Chromaticities could not be parsed. It needs to be 8 values separated by spaces. Unparsable: '" + CString(ocioChromaticitiesString) + L"'", siWarningMsg);
          }
       }
       CNodeSetter::SetPointer(in_optionsNode, "color_manager", ocioNode);

--- a/plugins/sitoa/loader/Options.h
+++ b/plugins/sitoa/loader/Options.h
@@ -58,6 +58,8 @@ public:
 void LoadPlayControlData(AtNode* in_optionsNode, double in_frame);
 // Load the output filters
 bool LoadFilters();
+// Load the color manager
+bool LoadColorManager(AtNode* in_optionsNode, double in_frame);
 // Load the drivers
 bool LoadDrivers(AtNode *in_optionsNode, Pass &in_pass, double in_frame, bool in_flythrough);
 // Load the options parameters

--- a/plugins/sitoa/renderer/RendererOptions.cpp
+++ b/plugins/sitoa/renderer/RendererOptions.cpp
@@ -946,7 +946,7 @@ SITOA_CALLBACK CommonRenderOptions_DefineLayout(CRef& in_ctxt)
    layout.AddTab(L"Color Management");
    layout.AddGroup(L"Color Manager");
       CValueArray color_managers;
-      color_managers.Add(L"None"); color_managers.Add(L"");
+      color_managers.Add(L"Built-in"); color_managers.Add(L"");
       color_managers.Add(L"OCIO"); color_managers.Add(L"color_manager_ocio");
       item = layout.AddEnumControl(L"color_manager", color_managers, L"Color Manager", siControlCombo);
       item.PutAttribute(siUINoLabel, true);

--- a/plugins/sitoa/renderer/RendererOptions.cpp
+++ b/plugins/sitoa/renderer/RendererOptions.cpp
@@ -958,7 +958,7 @@ SITOA_CALLBACK CommonRenderOptions_DefineLayout(CRef& in_ctxt)
          item.PutAttribute(siUIOpenFile, true);
          item.PutAttribute(siUIFileMustExist, true);
          item.PutAttribute(siUIFileFilter, L"OCIO config files (*.ocio)|*.ocio||");
-         item = layout.AddItem(L"ocio_config_message", L"", siControlStatic);
+         item = layout.AddItem(L"ocio_config_message", L"\n", siControlStatic);
       layout.EndGroup();
       CValueArray colorSpaces(2);
       colorSpaces[0] = L""; colorSpaces[1] = L"";
@@ -1449,18 +1449,18 @@ void ColorManagersTabLogic(CustomProperty &in_cp, PPGEventContext &in_ctxt)
    if (paramName != L"ocio_color_space_linear") {
       if (ocioManager) {
          if (hasOcioEnv && ocioConfig == L"") {
-            in_cp.PutParameterValue(L"ocio_config_message", CString(L"Using OCIO config from environment."));
+            in_cp.PutParameterValue(L"ocio_config_message", CString(L"Using OCIO config from environment.\n"));
             ocioLoaded = true;
          }
          else if (ocioConfig != L"") {
-            in_cp.PutParameterValue(L"ocio_config_message", CString(L"Using the specified OCIO config."));
+            in_cp.PutParameterValue(L"ocio_config_message", CString(L"Using the specified OCIO config.\n"));
             ocioLoaded = true;
          }
          else
             in_cp.PutParameterValue(L"ocio_config_message", CString(L"No OCIO in environment.\nLoad a config manually to use OCIO."));
       }
       else
-         in_cp.PutParameterValue(L"ocio_config_message", CString(L""));
+         in_cp.PutParameterValue(L"ocio_config_message", CString(L"\n"));
 
       if (ocioLoaded) {
          // init strings to get default colorspaces
@@ -1502,7 +1502,7 @@ void ColorManagersTabLogic(CustomProperty &in_cp, PPGEventContext &in_ctxt)
 
          }
          else {
-            in_cp.PutParameterValue(L"ocio_config_message", CString(L"Error: No color spaces found!"));
+            in_cp.PutParameterValue(L"ocio_config_message", CString(L"Error: No color spaces found!\n"));
          }
 
          // destroy the universe

--- a/plugins/sitoa/renderer/RendererOptions.cpp
+++ b/plugins/sitoa/renderer/RendererOptions.cpp
@@ -955,7 +955,9 @@ SITOA_CALLBACK CommonRenderOptions_DefineLayout(CRef& in_ctxt)
       layout.AddGroup(L"Config");
          item = layout.AddItem(L"ocio_config", L"Config", siControlFilePath);
          item.PutAttribute(siUINoLabel, true);
-         //item.PutAttribute(siUILabelMinPixels, 40);
+         item.PutAttribute(siUIOpenFile, true);
+         item.PutAttribute(siUIFileMustExist, true);
+         item.PutAttribute(siUIFileFilter, L"OCIO config files (*.ocio)|*.ocio||");
          item = layout.AddItem(L"ocio_config_message", L"", siControlStatic);
       layout.EndGroup();
       CValueArray colorSpaces(2);
@@ -1470,12 +1472,17 @@ void ColorManagersTabLogic(CustomProperty &in_cp, PPGEventContext &in_ctxt)
          // we need to have an arnold universe with the ocio node so that we can get all the color spaces
          bool defaultUniverseExist = AiUniverseIsActive();
          AtUniverse* ocioUniverse;
-         if (defaultUniverseExist)
-            ocioUniverse = AiUniverse();
-         else
-            AiBegin();
+         AtNode* ocioNode;
 
-         AtNode* ocioNode = AiNode("color_manager_ocio");
+         if (defaultUniverseExist) {
+            ocioUniverse = AiUniverse();
+            ocioNode = AiNode(ocioUniverse, "color_manager_ocio");
+         }
+         else {
+            AiBegin();
+            ocioNode = AiNode("color_manager_ocio");
+         }
+
          CNodeSetter::SetString(ocioNode, "config", GetRenderOptions()->m_ocio_config.GetAsciiString());
 
          int numColorSpaces = AiColorManagerGetNumColorSpaces(ocioNode);
@@ -1495,7 +1502,7 @@ void ColorManagersTabLogic(CustomProperty &in_cp, PPGEventContext &in_ctxt)
 
          }
          else {
-            in_cp.PutParameterValue(L"ocio_config_message", CString(L"Error: No color spaces found in current config!"));
+            in_cp.PutParameterValue(L"ocio_config_message", CString(L"Error: No color spaces found!"));
          }
 
          // destroy the universe

--- a/plugins/sitoa/renderer/RendererOptions.h
+++ b/plugins/sitoa/renderer/RendererOptions.h
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and limitations 
 
 #include "sitoa.h"
 
+#include <xsi_ppgeventcontext.h>
 #include <xsi_customproperty.h>
 #include <xsi_color4f.h>
 #include <xsi_utils.h>
@@ -158,6 +159,13 @@ public:
    bool  m_use_existing_tx_files;
    int   m_texture_max_memory_MB;
    int   m_texture_max_open_files;
+
+   // color managers
+   CString m_color_manager;
+   CString m_ocio_config;
+   CString m_ocio_color_space_narrow;
+   CString m_ocio_color_space_linear;
+   CString m_ocio_linear_chromaticities;
 
    // diagnostic
    bool         m_enable_log_console;
@@ -322,6 +330,13 @@ public:
       m_texture_max_memory_MB(2048),
       m_texture_max_open_files(100),
 
+      // color managers
+      m_color_manager(L"none"),
+      m_ocio_config(L""),
+      m_ocio_color_space_narrow(L""),
+      m_ocio_color_space_linear(L""),
+      m_ocio_linear_chromaticities(L""),
+
       // diagnostic
       m_enable_log_console(true),
       m_enable_log_file(false),
@@ -392,6 +407,8 @@ void SystemTabLogic(CustomProperty &in_cp);
 void OutputTabLogic(CustomProperty &in_cp);
 // Logic for the textures tab
 void TexturesTabLogic(CustomProperty &in_cp);
+// Logic for the color managers tab
+void ColorManagersTabLogic(CustomProperty &in_cp, PPGEventContext &in_ctxt);
 // Logic for the subdivision tab
 void SubdivisionTabLogic(CustomProperty &in_cp);
 // Logic for the diagnostics tab
@@ -400,6 +417,6 @@ void DiagnosticsTabLogic(CustomProperty &in_cp);
 void AssOutputTabLogic(CustomProperty &in_cp);
 
 // Reset the default values of all the parameters
-void ResetToDefault(CustomProperty &in_cp);
+void ResetToDefault(CustomProperty &in_cp, PPGEventContext &in_ctxt);
 
 


### PR DESCRIPTION
Okay, so this is a pretty big one and it's really an important feature for our studio that has been rendering in ACEScg for several years. Now we can integrate Softimage seamlessly in the color pipeline.

To dynamically fill the drop downs with the available color spaces, SItoA creates a new Arnold universe in order to get all OCIO color spaces through the Arnold API.
It recognizes the OCIO environment variable, but that can be overridden if you manually pick a config. Error message is shown if there are no color spaces found in the path.

![ocio_color_manager_env](https://user-images.githubusercontent.com/23527584/46706425-a695c900-cc34-11e8-8cfd-883a75768984.png)

If you want to specify your own chromaticities, it needs to be a string of 8 floats separated by spaces.

Testsuite passed.
This closes #31 