### PR TITLE
Fix export of camera screen_window_min/max

### DIFF
--- a/plugins/sitoa/common/ParamsCamera.cpp
+++ b/plugins/sitoa/common/ParamsCamera.cpp
@@ -106,16 +106,17 @@ CStatus LoadCameraParameters(AtNode* in_cameraNode, const Camera &in_xsiCamera, 
 
       // Set the screen_window values which are default arnold camera properties
       // This was broken in SItoA 4.1, but fixed on Github: https://github.com/Autodesk/sitoa/issues/42
-      // It moved in to the for loop to support motion blur at the same time it was fixed
+      // It moved in to the for-loop because these values are of array type even though they doesn't support motion blur (yet?)
+      // IF it supports motion blur in the future, we can simply change in_frame to frame in all the (float)ParAcc_GetValue() below
       AtVector2 screenWindowMin;
       AtVector2 screenWindowMax;
       float orthoSubpixelMultiplier = 1.0f;
       if (ParAcc_GetValue(in_xsiCamera, L"proj", in_frame) == 0)
       {
          // Orthographic camera
-         float width  = (float)ParAcc_GetValue(in_xsiCamera, L"planewidth", frame);
-         float height = (float)ParAcc_GetValue(in_xsiCamera, L"orthoheight", frame);
-         float aspect = (float)ParAcc_GetValue(in_xsiCamera, L"aspect", frame);
+         float width  = (float)ParAcc_GetValue(in_xsiCamera, L"planewidth", in_frame);
+         float height = (float)ParAcc_GetValue(in_xsiCamera, L"orthoheight", in_frame);
+         float aspect = (float)ParAcc_GetValue(in_xsiCamera, L"aspect", in_frame);
          orthoSubpixelMultiplier = height/2*aspect;
    
          screenWindowMin.x = -width/2;
@@ -129,13 +130,13 @@ CStatus LoadCameraParameters(AtNode* in_cameraNode, const Camera &in_xsiCamera, 
          
          if ((bool)ParAcc_GetValue(in_xsiCamera, L"projplane", in_frame))
          {
-            float offsetX = (float)ParAcc_GetValue(in_xsiCamera, L"projplaneoffx", frame);
-            float offsetY = (float)ParAcc_GetValue(in_xsiCamera, L"projplaneoffy", frame);
+            float offsetX = (float)ParAcc_GetValue(in_xsiCamera, L"projplaneoffx", in_frame);
+            float offsetY = (float)ParAcc_GetValue(in_xsiCamera, L"projplaneoffy", in_frame);
             
             if (offsetX!=0.0f || offsetY!=0.0f)
             {
-               float apertureX = (float)ParAcc_GetValue(in_xsiCamera, L"projplanewidth", frame);
-               float apertureY = (float)ParAcc_GetValue(in_xsiCamera, L"projplaneheight", frame);
+               float apertureX = (float)ParAcc_GetValue(in_xsiCamera, L"projplanewidth", in_frame);
+               float apertureY = (float)ParAcc_GetValue(in_xsiCamera, L"projplaneheight", in_frame);
    
                factorX = (offsetX / apertureX) * 2;
                factorY = (offsetY / apertureY) * 2;
@@ -152,10 +153,10 @@ CStatus LoadCameraParameters(AtNode* in_cameraNode, const Camera &in_xsiCamera, 
       // The subpixelzoom mode should only affects a render region mode
       if (GetRenderInstance()->GetRenderType() == L"Region" && (bool)ParAcc_GetValue(in_xsiCamera, L"subpixelzoom", in_frame))
       {
-         float subfrustumleft   = ParAcc_GetValue(in_xsiCamera, L"subfrustumleft",   frame);
-         float subfrustumright  = ParAcc_GetValue(in_xsiCamera, L"subfrustumright",  frame);
-         float subfrustumtop    = ParAcc_GetValue(in_xsiCamera, L"subfrustumtop",    frame);
-         float subfrustumbottom = ParAcc_GetValue(in_xsiCamera, L"subfrustumbottom", frame);
+         float subfrustumleft   = ParAcc_GetValue(in_xsiCamera, L"subfrustumleft",   in_frame);
+         float subfrustumright  = ParAcc_GetValue(in_xsiCamera, L"subfrustumright",  in_frame);
+         float subfrustumtop    = ParAcc_GetValue(in_xsiCamera, L"subfrustumtop",    in_frame);
+         float subfrustumbottom = ParAcc_GetValue(in_xsiCamera, L"subfrustumbottom", in_frame);
 
          screenWindowMin.x += subfrustumleft * orthoSubpixelMultiplier * 2.0f;
          screenWindowMin.y += subfrustumbottom * orthoSubpixelMultiplier * 2.0f;

--- a/plugins/sitoa/common/ParamsCamera.cpp
+++ b/plugins/sitoa/common/ParamsCamera.cpp
@@ -109,12 +109,14 @@ CStatus LoadCameraParameters(AtNode* in_cameraNode, const Camera &in_xsiCamera, 
       // It moved in to the for loop to support motion blur at the same time it was fixed
       AtVector2 screenWindowMin;
       AtVector2 screenWindowMax;
+      float orthoSubpixelMultiplier = 1.0f;
       if (ParAcc_GetValue(in_xsiCamera, L"proj", in_frame) == 0)
       {
          // Orthographic camera
          float width  = (float)ParAcc_GetValue(in_xsiCamera, L"planewidth", frame);
          float height = (float)ParAcc_GetValue(in_xsiCamera, L"orthoheight", frame);
          float aspect = (float)ParAcc_GetValue(in_xsiCamera, L"aspect", frame);
+         orthoSubpixelMultiplier = height/2*aspect;
    
          screenWindowMin.x = -width/2;
          screenWindowMin.y = -height/2*aspect;
@@ -155,10 +157,10 @@ CStatus LoadCameraParameters(AtNode* in_cameraNode, const Camera &in_xsiCamera, 
          float subfrustumtop    = ParAcc_GetValue(in_xsiCamera, L"subfrustumtop",    frame);
          float subfrustumbottom = ParAcc_GetValue(in_xsiCamera, L"subfrustumbottom", frame);
 
-         screenWindowMin.x += subfrustumleft * 2.0f;
-         screenWindowMin.y += subfrustumbottom * 2.0f;
-         screenWindowMax.x += (subfrustumright - 1.0f) * 2.0f;
-         screenWindowMax.y += (subfrustumtop - 1.0f) * 2.0f;
+         screenWindowMin.x += subfrustumleft * orthoSubpixelMultiplier * 2.0f;
+         screenWindowMin.y += subfrustumbottom * orthoSubpixelMultiplier * 2.0f;
+         screenWindowMax.x += (subfrustumright - 1.0f) * orthoSubpixelMultiplier * 2.0f;
+         screenWindowMax.y += (subfrustumtop - 1.0f) * orthoSubpixelMultiplier * 2.0f;
       }
 
       AiArraySetVec2(screenWindowMins, ikey, screenWindowMin);

--- a/plugins/sitoa/loader/Properties.cpp
+++ b/plugins/sitoa/loader/Properties.cpp
@@ -593,14 +593,9 @@ void LoadCameraOptions(const Camera &in_xsiCamera, AtNode* in_node, const Proper
          CNodeSetter::SetFloat(in_node, "aperture_blade_curvature", apertureBladeCurvature); 
          CNodeSetter::SetFloat(in_node, "aperture_rotation",        apertureRotation); 
          CNodeSetter::SetFloat(in_node, "aperture_aspect_ratio",    apertureAspectRatio);       
-      }
-      else
-      {
-         aperture_size = AiArrayAllocate(1, 1, AI_TYPE_FLOAT);
-         AiArraySetFlt(aperture_size, 0, 0.0f);
-      }
 
-      AiNodeSetArray(in_node, "aperture_size", aperture_size);
+         AiNodeSetArray(in_node, "aperture_size", aperture_size);
+      }
    }
 
    if (focus_distance)


### PR DESCRIPTION
So here's what I've done.
First, I put all the code for the screen windows inside the loop that sets other array values like `matrix` and `fov`. This means that screen windows are now exported with proper motion blur samples.
I also changed the logic. Before it went something like this:
```cpp
if (subpixelzoom)
   // set screen windows for Subpixel Zoom
else if (orthographic)
   // set screen windows for Orthographic
else
   // set screen windows for Optical Center Shift
```
That makes each mode exclusive, which means you can't use optical shift or orthographic and subpixel zoom at the same time. So I changed it to this:
```cpp
if (orthographic)
   // set screen windows for Orthographic
else
   // set screen windows for Optical Center Shift
if (subpixelzoom)
   // offset screen windows for Subpixel Zoom
```
Now subpixel zoom can be used together with Optical Center Shift and Orthographic cameras.

While testing this, I exported a couple of .asses with and without motion blur and as far as I can see all parameters of the `persp_camera` is exported properly now.
I noticed however that `aperture_size` is exported with a value of 0 if the camera has a Arnold_Camera_Options on it, even if DoF is disabled. I removed that as well just to clean up a bit.

Passes testsuite and closes #42 