### PR TITLE
Basic OptiX support

### DIFF
--- a/plugins/sitoa/loader/Options.cpp
+++ b/plugins/sitoa/loader/Options.cpp
@@ -688,6 +688,10 @@ void LoadOptionsParameters(AtNode* in_optionsNode, const Property &in_arnoldOpti
    int nb_threads = GetRenderOptions()->m_autodetect_threads ? 0 : GetRenderOptions()->m_threads;
    CNodeSetter::SetInt(in_optionsNode, "threads", nb_threads); 
 
+   // GPU devices
+   CNodeSetter::SetString(in_optionsNode, "gpu_default_names", GetRenderOptions()->m_gpu_default_names.GetAsciiString());
+   CNodeSetter::SetInt(in_optionsNode, "gpu_default_min_memory_MB", GetRenderOptions()->m_gpu_default_min_memory_MB);
+
    // #680
    LoadUserOptions(in_optionsNode, in_arnoldOptions, in_frame);
 }

--- a/plugins/sitoa/loader/Options.cpp
+++ b/plugins/sitoa/loader/Options.cpp
@@ -489,7 +489,7 @@ bool LoadDrivers(AtNode *in_optionsNode, Pass &in_pass, double in_frame, bool in
             deepExrLayersDrivers.push_back(CDeepExrLayersDrivers(masterFb.m_fullName, thisFb.m_layerName, thisFb.m_driverBitDepth));
       }
 
-      // if layerName ends with "_denoise"
+      // if layerName ends with "_denoise", we add a denoise filter named after the layer and then add the output
       if (thisFb.m_layerName.ReverseFindString(L"_denoise") == (thisFb.m_layerName.Length() - CString(L"_denoise").Length()))
       {
          // OptiX denoise needs a separete filter for each AOV, so we create them here instad of in LoadFilters()

--- a/plugins/sitoa/renderer/DisplayDriver.cpp
+++ b/plugins/sitoa/renderer/DisplayDriver.cpp
@@ -374,7 +374,7 @@ void DisplayDriver::UpdateDisplayDriver(RendererContext& in_rendererContext, uns
       if (layerdataType.IsEqualNoCase(L""))
          layerdataType = GetDriverLayerChannelType((LONG)renderchannel.GetChannelType());
 
-      // if layerName ends with "_denoise"
+      // if layerName ends with "_denoise", we connect the driver to the optix filter for that layer
       if (layerName.ReverseFindString(L"_denoise") == (layerName.Length() - CString(L"_denoise").Length()))
       {
          displayDriver = layerName + L" " + layerdataType + L" sitoa_" + layerName + L"_optix_filter xsi_driver";

--- a/plugins/sitoa/renderer/DisplayDriver.cpp
+++ b/plugins/sitoa/renderer/DisplayDriver.cpp
@@ -377,7 +377,16 @@ void DisplayDriver::UpdateDisplayDriver(RendererContext& in_rendererContext, uns
       // if layerName ends with "_denoise", we connect the driver to the optix filter for that layer
       if (layerName.ReverseFindString(L"_denoise") == (layerName.Length() - CString(L"_denoise").Length()))
       {
-         displayDriver = layerName + L" " + layerdataType + L" sitoa_" + layerName + L"_optix_filter xsi_driver";
+         // we need to check if the optix filter exist. If it doesn't exist, we create one.
+         CString optixFilterName = L"sitoa_" + layerName + L"_optix_filter";
+         AtNode* optixFilterNode = AiNodeLookUpByName(optixFilterName.GetAsciiString());
+         if (!optixFilterNode)
+         {
+            optixFilterNode = AiNode("denoise_optix_filter");
+            if (optixFilterNode)
+               CNodeUtilities().SetName(optixFilterNode, optixFilterName.GetAsciiString());
+         }
+         displayDriver = layerName + L" " + layerdataType + L" " + optixFilterName + " xsi_driver";
       }
       else if (layerdataType.IsEqualNoCase(L"RGB") || layerdataType.IsEqualNoCase(L"RGBA"))
       {

--- a/plugins/sitoa/renderer/DisplayDriver.cpp
+++ b/plugins/sitoa/renderer/DisplayDriver.cpp
@@ -374,7 +374,12 @@ void DisplayDriver::UpdateDisplayDriver(RendererContext& in_rendererContext, uns
       if (layerdataType.IsEqualNoCase(L""))
          layerdataType = GetDriverLayerChannelType((LONG)renderchannel.GetChannelType());
 
-      if (layerdataType.IsEqualNoCase(L"RGB") || layerdataType.IsEqualNoCase(L"RGBA"))
+      // if layerName ends with "_denoise"
+      if (layerName.ReverseFindString(L"_denoise") == (layerName.Length() - CString(L"_denoise").Length()))
+      {
+         displayDriver = layerName + L" " + layerdataType + L" sitoa_" + layerName + L"_optix_filter xsi_driver";
+      }
+      else if (layerdataType.IsEqualNoCase(L"RGB") || layerdataType.IsEqualNoCase(L"RGBA"))
       {
          if (in_filterColorAov)
             displayDriver = layerName + L" " + layerdataType + L" sitoa_output_filter xsi_driver";

--- a/plugins/sitoa/renderer/Drivers.cpp
+++ b/plugins/sitoa/renderer/Drivers.cpp
@@ -43,6 +43,10 @@ CString GetLayerName(const CString &in_datatype)
    if (in_datatype.IsEqualNoCase(L"Main"))
       return L"RGBA";
 
+   // If someone where to create a denoise of "Main" lets handle that as well
+   if (in_datatype.IsEqualNoCase(L"Main_denoise"))
+      return L"RGBA_denoise";
+
    // is this one of the AOVs created by CreateRenderChannels in ArnoldScenePreferences.js ?
    if (in_datatype.FindString(L"Arnold_") == 0) // trim the "Arnold_" prefix, so to get back the Arnold factory name
       return CStringUtilities().ReplaceString(L"Arnold_", L"", in_datatype);

--- a/plugins/sitoa/renderer/RendererOptions.cpp
+++ b/plugins/sitoa/renderer/RendererOptions.cpp
@@ -34,6 +34,10 @@ void CRenderOptions::Read(const Property &in_cp)
    // system
    m_autodetect_threads    = (bool)ParAcc_GetValue(in_cp, L"autodetect_threads",    DBL_MAX);
    m_threads               = (int) ParAcc_GetValue(in_cp, L"threads",               DBL_MAX);
+
+   m_gpu_default_names         = ParAcc_GetValue(in_cp,       L"gpu_default_names",         DBL_MAX).GetAsText();
+   m_gpu_default_min_memory_MB = (int) ParAcc_GetValue(in_cp, L"gpu_default_min_memory_MB", DBL_MAX);
+
    m_bucket_scanning       = ParAcc_GetValue(in_cp,       L"bucket_scanning",       DBL_MAX).GetAsText();
    m_bucket_size           = (int)ParAcc_GetValue(in_cp,  L"bucket_size",           DBL_MAX);
    m_progressive_minus3    = (bool)ParAcc_GetValue(in_cp, L"progressive_minus3",    DBL_MAX);
@@ -293,6 +297,10 @@ SITOA_CALLBACK CommonRenderOptions_Define(CRef& in_ctxt)
    // system
    cpset.AddParameter(L"autodetect_threads",     CValue::siBool,   siPersistable, L"", L"", true, CValue(), CValue(), CValue(), CValue(), p);
    cpset.AddParameter(L"threads",                CValue::siInt4,   siPersistable, L"", L"", 4, -AI_MAX_THREADS, AI_MAX_THREADS, 1, AI_MAX_THREADS, p);
+
+   cpset.AddParameter(L"gpu_default_names",         CValue::siString, siPersistable, L"", L"",  L"*", CValue(), CValue(), CValue(), CValue(), p);
+   cpset.AddParameter(L"gpu_default_min_memory_MB", CValue::siInt4,   siPersistable, L"", L"", 512, 0, 10000000, 256, 1024, p);
+
    cpset.AddParameter(L"bucket_scanning",        CValue::siString, siPersistable, L"", L"", L"spiral", CValue(), CValue(), CValue(), CValue(), p);
    cpset.AddParameter(L"bucket_size",            CValue::siInt4,   siPersistable, L"", L"",  64, 16, 256, 16, 256, p);
    cpset.AddParameter(L"progressive_minus3",     CValue::siBool,   siPersistable, L"", L"",  true, CValue(), CValue(), CValue(), CValue(), p);
@@ -574,6 +582,12 @@ SITOA_CALLBACK CommonRenderOptions_DefineLayout(CRef& in_ctxt)
       layout.AddItem(L"autodetect_threads", L"Autodetect");
       item = layout.AddItem(L"threads", L"Number of Threads");
       item.PutAttribute(siUILabelPercentage, 100);
+   layout.EndGroup();
+   layout.AddGroup(L"Devices");
+      item = layout.AddItem(L"gpu_default_names", L"GPU Names");
+      item.PutAttribute(siUILabelMinPixels, 100);
+      item = layout.AddItem(L"gpu_default_min_memory_MB", L"Min. Memory (MB)");
+      item.PutAttribute(siUILabelMinPixels, 100);
    layout.EndGroup();
    layout.AddGroup(L"Buckets", true, 0);
       CValueArray scanning;

--- a/plugins/sitoa/renderer/RendererOptions.h
+++ b/plugins/sitoa/renderer/RendererOptions.h
@@ -46,6 +46,8 @@ public:
    // system
    bool     m_autodetect_threads;
    int      m_threads;
+   CString  m_gpu_default_names;
+   int      m_gpu_default_min_memory_MB;
    CString  m_bucket_scanning;
    int      m_bucket_size;
    bool     m_progressive_minus3;
@@ -219,6 +221,8 @@ public:
       // system
       m_autodetect_threads(true),
       m_threads(4),
+      m_gpu_default_names(L"*"),
+      m_gpu_default_min_memory_MB(512),
       m_bucket_scanning(L"spiral"),
       m_bucket_size(64),
       m_progressive_minus3(true),


### PR DESCRIPTION
I had a look at MAXtoA to see how OptiX worked there and I guess it's similar to how the other plugins work. If you check Denoise on any AOV in MAXtoA, it will create a new AOV with "_denoise" as suffix.
Since SItoA rely on the very limited Render Channels interface that's built in to Softimage, I had to go a different route...

What you do in SItoA is that you simply create a new Render Channel for the AOV that you want to denoise and simply name it with _denoise as suffix.
So lets say you want to denoise the `Main` Render Channel. Then just create a new render channel called `Main_denoise`.

One current limitation with OptiX is that the denoised AOV can't be written to a multipart EXR. So make sure it has it's own filename output.

I also added Devices to the System tab. But only the auto selection part. It's a lot more work to add the manual selection of GPU. I don't feel it's needed for OptiX but maybe with more powerful GPU things we need manual control over the GPU selection.