### PR TITLE
Progressive Rendering

### DIFF
--- a/plugins/sitoa/loader/Options.cpp
+++ b/plugins/sitoa/loader/Options.cpp
@@ -568,6 +568,7 @@ void LoadOptionsParameters(AtNode* in_optionsNode, const Property &in_arnoldOpti
    CNodeSetter::SetInt(in_optionsNode, "GI_transmission_samples", GetRenderOptions()->m_GI_transmission_samples);
    CNodeSetter::SetInt(in_optionsNode, "GI_sss_samples",          GetRenderOptions()->m_GI_sss_samples);
    CNodeSetter::SetInt(in_optionsNode, "GI_volume_samples",       GetRenderOptions()->m_GI_volume_samples);
+   CNodeSetter::SetBoolean(in_optionsNode, "enable_progressive_render", GetRenderOptions()->m_enable_progressive_render);
 
    CNodeSetter::SetBoolean(in_optionsNode, "enable_adaptive_sampling", GetRenderOptions()->m_enable_adaptive_sampling);
    CNodeSetter::SetInt(in_optionsNode, "AA_samples_max",               GetRenderOptions()->m_AA_samples_max);

--- a/plugins/sitoa/loader/Options.cpp
+++ b/plugins/sitoa/loader/Options.cpp
@@ -526,7 +526,7 @@ void LoadOptionsParameters(AtNode* in_optionsNode, const Property &in_arnoldOpti
 
    CNodeSetter::SetInt(in_optionsNode, "xres", width);
    CNodeSetter::SetInt(in_optionsNode, "yres", height);
-   if (aspectRatio > 0.0f)
+   if (aspectRatio > 0.0f && (fabs(aspectRatio-1.0f) > AI_EPSILON))
       CNodeSetter::SetFloat(in_optionsNode, "pixel_aspect_ratio", 1.0f / aspectRatio);
 
    // cropping

--- a/plugins/sitoa/loader/Options.cpp
+++ b/plugins/sitoa/loader/Options.cpp
@@ -568,7 +568,11 @@ void LoadOptionsParameters(AtNode* in_optionsNode, const Property &in_arnoldOpti
    CNodeSetter::SetInt(in_optionsNode, "GI_transmission_samples", GetRenderOptions()->m_GI_transmission_samples);
    CNodeSetter::SetInt(in_optionsNode, "GI_sss_samples",          GetRenderOptions()->m_GI_sss_samples);
    CNodeSetter::SetInt(in_optionsNode, "GI_volume_samples",       GetRenderOptions()->m_GI_volume_samples);
-   CNodeSetter::SetBoolean(in_optionsNode, "enable_progressive_render", GetRenderOptions()->m_enable_progressive_render);
+
+   // only export progressive if in interactive mode but not if exporting .ass
+   CString renderType = GetRenderInstance()->GetRenderType();
+   if (Application().IsInteractive() && (renderType != L"Export"))
+      CNodeSetter::SetBoolean(in_optionsNode, "enable_progressive_render", GetRenderOptions()->m_enable_progressive_render);
 
    CNodeSetter::SetBoolean(in_optionsNode, "enable_adaptive_sampling", GetRenderOptions()->m_enable_adaptive_sampling);
    CNodeSetter::SetInt(in_optionsNode, "AA_samples_max",               GetRenderOptions()->m_AA_samples_max);

--- a/plugins/sitoa/renderer/DisplayDriver.cpp
+++ b/plugins/sitoa/renderer/DisplayDriver.cpp
@@ -183,6 +183,12 @@ driver_process_bucket
    // Progress bar
    displayDriver->m_paintedDisplayArea += (bucket_size_x * bucket_size_y);
    int percent = (int)((displayDriver->m_paintedDisplayArea / (float)displayDriver->m_displayArea) * 100.0f);
+   // if in progressive render mode we need to divide percent by number of samples
+   AtNode* options = AiUniverseGetOptions();
+   bool progressive = AiNodeGetBool(options, "enable_progressive_render");
+   int aa_samples = AiNodeGetInt(options, "AA_samples");
+   if (progressive && (aa_samples > 1))
+      percent = percent / (aa_samples * aa_samples);
    displayDriver->m_renderContext.ProgressUpdate(CValue(percent).GetAsText() + L"%   Rendered", L"Rendering", percent);
 
    if (!AiOutputIteratorGetNext(iterator, NULL, &pixel_type, &bucket_data))

--- a/plugins/sitoa/renderer/DisplayDriver.cpp
+++ b/plugins/sitoa/renderer/DisplayDriver.cpp
@@ -180,7 +180,12 @@ driver_process_bucket
    // get parameters necessary for progressive progress bar
    AtNode* options = AiUniverseGetOptions();
    bool progressive = AiNodeGetBool(options, "enable_progressive_render");
-   int aa_samples = AiNodeGetInt(options, "AA_samples");
+   int aaSamples = AiNodeGetInt(options, "AA_samples");
+   bool adaptiveSampling = AiNodeGetBool(options, "enable_adaptive_sampling");
+   int aaSamplesMax = AiNodeGetInt(options, "AA_samples_max");
+   int progressivePasses = aaSamples * aaSamples;
+   if (adaptiveSampling && (aaSamplesMax > aaSamples))
+      progressivePasses = aaSamplesMax * aaSamplesMax;
 
    if (renderInstance->InterruptRenderSignal())
       return;
@@ -189,8 +194,8 @@ driver_process_bucket
    displayDriver->m_paintedDisplayArea += (bucket_size_x * bucket_size_y);
    int percent = (int)((displayDriver->m_paintedDisplayArea / (float)displayDriver->m_displayArea) * 100.0f);
    // if in progressive render mode we need to divide percent by number of progressive passes
-   if (progressive && (aa_samples > 1))
-      percent = percent / (aa_samples * aa_samples);
+   if (progressive && (progressivePasses > 1))
+      percent = percent / progressivePasses;
    displayDriver->m_renderContext.ProgressUpdate(CValue(percent).GetAsText() + L"%   Rendered", L"Rendering", percent);
 
    if (!AiOutputIteratorGetNext(iterator, NULL, &pixel_type, &bucket_data))

--- a/plugins/sitoa/renderer/DisplayDriver.cpp
+++ b/plugins/sitoa/renderer/DisplayDriver.cpp
@@ -177,16 +177,18 @@ driver_process_bucket
    CRenderInstance* renderInstance = GetRenderInstance();
    DisplayDriver* displayDriver = renderInstance->GetDisplayDriver();
    
+   // get parameters necessary for progressive progress bar
+   AtNode* options = AiUniverseGetOptions();
+   bool progressive = AiNodeGetBool(options, "enable_progressive_render");
+   int aa_samples = AiNodeGetInt(options, "AA_samples");
+
    if (renderInstance->InterruptRenderSignal())
       return;
 
    // Progress bar
    displayDriver->m_paintedDisplayArea += (bucket_size_x * bucket_size_y);
    int percent = (int)((displayDriver->m_paintedDisplayArea / (float)displayDriver->m_displayArea) * 100.0f);
-   // if in progressive render mode we need to divide percent by number of samples
-   AtNode* options = AiUniverseGetOptions();
-   bool progressive = AiNodeGetBool(options, "enable_progressive_render");
-   int aa_samples = AiNodeGetInt(options, "AA_samples");
+   // if in progressive render mode we need to divide percent by number of progressive passes
    if (progressive && (aa_samples > 1))
       percent = percent / (aa_samples * aa_samples);
    displayDriver->m_renderContext.ProgressUpdate(CValue(percent).GetAsText() + L"%   Rendered", L"Rendering", percent);

--- a/plugins/sitoa/renderer/RenderInstance.cpp
+++ b/plugins/sitoa/renderer/RenderInstance.cpp
@@ -237,6 +237,8 @@ int CRenderInstance::RenderProgressiveScene()
    AtNode* options = AiUniverseGetOptions();
    // override the aspect ratio, for the viewport is always 1.0
    CNodeSetter::SetFloat(options, "pixel_aspect_ratio", 1.0);   
+   // disable adaptive AA during progressive rendering
+   CNodeSetter::SetBoolean(options, "enable_adaptive_sampling", false);
    // Disable random dithering during progressive rendering, for speed
    m_displayDriver.SetDisplayDithering(false);
    // loop the aa steps
@@ -245,6 +247,8 @@ int CRenderInstance::RenderProgressiveScene()
       // Enable dithering for the final pass of the progressive rendering
       if (*aa_it == aa_max)
       {
+         // restore adaptive sampling again on final aa pass
+         CNodeSetter::SetBoolean(options, "enable_adaptive_sampling", GetRenderOptions()->m_enable_adaptive_sampling);
          m_displayDriver.SetDisplayDithering(dither);
          AiMsgSetConsoleFlags(verbosity);
       }

--- a/plugins/sitoa/renderer/RenderInstance.cpp
+++ b/plugins/sitoa/renderer/RenderInstance.cpp
@@ -237,14 +237,14 @@ int CRenderInstance::RenderProgressiveScene()
    AtNode* options = AiUniverseGetOptions();
    // override the aspect ratio, for the viewport is always 1.0
    CNodeSetter::SetFloat(options, "pixel_aspect_ratio", 1.0);   
-   // disable adaptive sampling during progressive rendering
+   // disable adaptive sampling during negative aa passes
    CNodeSetter::SetBoolean(options, "enable_adaptive_sampling", false);
-   // Disable random dithering during progressive rendering, for speed
+   // Disable random dithering during negative aa passes, for speed
    m_displayDriver.SetDisplayDithering(false);
    // loop the aa steps
    for (set<int>::iterator aa_it = aa_steps.begin(); aa_it != aa_steps.end(); aa_it++)
    {
-      // Enable dithering for the final pass of the progressive rendering
+      // Enable dithering for the final pass of the rendering
       if (*aa_it == aa_max)
       {
          // restore adaptive sampling again on final aa pass

--- a/plugins/sitoa/renderer/RenderInstance.cpp
+++ b/plugins/sitoa/renderer/RenderInstance.cpp
@@ -225,8 +225,11 @@ int CRenderInstance::RenderProgressiveScene()
       aa_steps.insert(-2);
    if ((aa_max > -1) && GetRenderOptions()->m_progressive_minus1)
       aa_steps.insert(-1);
-   if ((aa_max > 1) && GetRenderOptions()->m_progressive_plus1)
-      aa_steps.insert(1);
+   if (!GetRenderOptions()->m_enable_progressive_render)
+   {
+      if ((aa_max > 1) && GetRenderOptions()->m_progressive_plus1)
+         aa_steps.insert(1);
+   }
 
    aa_steps.insert(aa_max); // the main value for aa, so aa_steps is never empty, and aaMax will always be the final step used
    

--- a/plugins/sitoa/renderer/RenderInstance.cpp
+++ b/plugins/sitoa/renderer/RenderInstance.cpp
@@ -237,7 +237,7 @@ int CRenderInstance::RenderProgressiveScene()
    AtNode* options = AiUniverseGetOptions();
    // override the aspect ratio, for the viewport is always 1.0
    CNodeSetter::SetFloat(options, "pixel_aspect_ratio", 1.0);   
-   // disable adaptive AA during progressive rendering
+   // disable adaptive sampling during progressive rendering
    CNodeSetter::SetBoolean(options, "enable_adaptive_sampling", false);
    // Disable random dithering during progressive rendering, for speed
    m_displayDriver.SetDisplayDithering(false);

--- a/plugins/sitoa/renderer/RendererOptions.cpp
+++ b/plugins/sitoa/renderer/RendererOptions.cpp
@@ -111,6 +111,7 @@ void CRenderOptions::Read(const Property &in_cp)
    m_GI_transmission_samples = (int)ParAcc_GetValue(in_cp, L"GI_transmission_samples", DBL_MAX);
    m_GI_sss_samples          = (int)ParAcc_GetValue(in_cp, L"GI_sss_samples",          DBL_MAX);
    m_GI_volume_samples       = (int)ParAcc_GetValue(in_cp, L"GI_volume_samples",       DBL_MAX);
+   m_enable_progressive_render = (bool)ParAcc_GetValue(in_cp, L"enable_progressive_render", DBL_MAX);
 
    m_enable_adaptive_sampling = (bool)ParAcc_GetValue(in_cp,  L"enable_adaptive_sampling", DBL_MAX);
    m_AA_samples_max           = (int)ParAcc_GetValue(in_cp,   L"AA_samples_max",           DBL_MAX);
@@ -384,6 +385,7 @@ SITOA_CALLBACK CommonRenderOptions_Define(CRef& in_ctxt)
    cpset.AddParameter(L"GI_transmission_samples", CValue::siInt4,   siPersistable, L"", L"", 2, 0, 100, 0, 10, p);
    cpset.AddParameter(L"GI_sss_samples",          CValue::siInt4,   siPersistable, L"", L"", 2, 0, 100, 0, 10, p);
    cpset.AddParameter(L"GI_volume_samples",       CValue::siInt4,   siPersistable, L"", L"", 2, 0, 100, 0, 10, p);
+   cpset.AddParameter(L"enable_progressive_render", CValue::siBool, siPersistable, L"", L"", false, CValue(), CValue(), CValue(), CValue(), p);
 
    cpset.AddParameter(L"enable_adaptive_sampling", CValue::siBool,   siPersistable, L"", L"", false, CValue(), CValue(), CValue(), CValue(), p);
    cpset.AddParameter(L"AA_samples_max",           CValue::siInt4,   siPersistable, L"", L"", 8, -3, 100, 0, 10, p);
@@ -796,6 +798,7 @@ SITOA_CALLBACK CommonRenderOptions_DefineLayout(CRef& in_ctxt)
       item.PutAttribute(siUILabelPercentage, 100);
       item = layout.AddItem(L"GI_volume_samples", L"Volume");
       item.PutAttribute(siUILabelPercentage, 100);
+      layout.AddItem(L"enable_progressive_render", L"Progressive Render");
    layout.EndGroup();
 
    layout.AddGroup(L"Adaptive Sampling");

--- a/plugins/sitoa/renderer/RendererOptions.h
+++ b/plugins/sitoa/renderer/RendererOptions.h
@@ -104,6 +104,7 @@ public:
    int     m_GI_transmission_samples;
    int     m_GI_sss_samples;
    int     m_GI_volume_samples;
+   bool     m_enable_progressive_render;
 
    bool    m_enable_adaptive_sampling;
    int     m_AA_samples_max;
@@ -273,6 +274,7 @@ public:
       m_GI_transmission_samples(2),
       m_GI_sss_samples(2),
       m_GI_volume_samples(2),
+      m_enable_progressive_render(false),
 
       m_enable_adaptive_sampling(false),
       m_AA_samples_max(8),


### PR DESCRIPTION
Had totally missed that progressive was a thing now.

**Done:**
- Progressive Rendering functionality
- Disable Adaptive AA on IPR
- Progress bar updates correctly when Progressive is enabled.
- Progressive Rendering is not exported in Batch mode or when exporting ass-archive.

While doing this I noticed that pixel_aspect_ratio was always exported, even if it was virtually 1.0.
So I added a check and only export pixel_aspect_ratio if it's more than AI_EPSILON away from 1.0.
