### PR TITLE
Support for Stats and Profiling Diagnostics

### DIFF
--- a/plugins/sitoa/common/Tools.cpp
+++ b/plugins/sitoa/common/Tools.cpp
@@ -1374,8 +1374,8 @@ void SetLogSettings(const CString& in_renderType, double in_frame)
    if (enableStats)
    {
       CPathString statsFile = GetRenderOptions()->m_stats_file;
-      statsFile = statsFile.ResolveTokens(CTimeUtilities().GetCurrentFrame());
-      statsFile = statsFile.ResolvePath();
+      statsFile.ResolveTokensInPlace(CTimeUtilities().GetCurrentFrame(), L"[Pass]");
+      statsFile.ResolvePathInPlace();
       if (CUtils::EnsureFolderExists(statsFile, true))
       {
          AiStatsSetFileName(statsFile.GetAsciiString());
@@ -1393,8 +1393,8 @@ void SetLogSettings(const CString& in_renderType, double in_frame)
    if (enableProfile)
    {
       CPathString profileFile = GetRenderOptions()->m_profile_file;
-      profileFile = profileFile.ResolveTokens(CTimeUtilities().GetCurrentFrame());
-      profileFile = profileFile.ResolvePath();
+      profileFile.ResolveTokensInPlace(CTimeUtilities().GetCurrentFrame(), L"[Pass]");
+      profileFile.ResolvePathInPlace();
       if (CUtils::EnsureFolderExists(profileFile, true))
       {
          AiProfileSetFileName(profileFile.GetAsciiString());

--- a/plugins/sitoa/common/Tools.cpp
+++ b/plugins/sitoa/common/Tools.cpp
@@ -1366,6 +1366,47 @@ void SetLogSettings(const CString& in_renderType, double in_frame)
       else
          GetMessageQueue()->LogMsg(L"[sitoa] Logging path is not valid", siWarningMsg);
    }
+
+   // stats and profile
+   bool enableStats        = GetRenderOptions()->m_enable_stats;
+   bool enableProfile      = GetRenderOptions()->m_enable_profile;
+
+   if (enableStats)
+   {
+      CPathString statsFile = GetRenderOptions()->m_stats_file;
+      statsFile = statsFile.ResolveTokens(CTimeUtilities().GetCurrentFrame());
+      statsFile = statsFile.ResolvePath();
+      if (CUtils::EnsureFolderExists(statsFile, true))
+      {
+         AiStatsSetFileName(statsFile.GetAsciiString());
+         AiStatsSetMode(AI_STATS_MODE_APPEND);
+      }
+      else
+      {
+         GetMessageQueue()->LogMsg(L"[sitoa] Logging Stats path is not valid", siWarningMsg);
+         AiStatsSetFileName("");
+      }
+   }
+   else
+      AiStatsSetFileName("");
+
+   if (enableProfile)
+   {
+      CPathString profileFile = GetRenderOptions()->m_profile_file;
+      profileFile = profileFile.ResolveTokens(CTimeUtilities().GetCurrentFrame());
+      profileFile = profileFile.ResolvePath();
+      if (CUtils::EnsureFolderExists(profileFile, true))
+      {
+         AiProfileSetFileName(profileFile.GetAsciiString());
+      }
+      else
+      {
+         GetMessageQueue()->LogMsg(L"[sitoa] Logging Profile path is not valid", siWarningMsg);
+         AiProfileSetFileName("");
+      }
+   }
+   else
+      AiProfileSetFileName("");
 }
 
 

--- a/plugins/sitoa/loader/PathTranslator.cpp
+++ b/plugins/sitoa/loader/PathTranslator.cpp
@@ -34,6 +34,11 @@ CPathString CPathString::ResolveTokens(double in_frame, CString in_extraToken)
          *this = CStringUtilities().ReplaceString(L"[pass]", pass.GetName(), *this);  // lowercase quick fix
       }
    }
+
+   // because of a bug? in Softimage SDK the [Frame] token is not using the scene padding settings
+   *this = CStringUtilities().ReplaceString(L"[Frame]", GetFramePadded(in_frame), *this);
+   *this = CStringUtilities().ReplaceString(L"[frame]", GetFramePadded(in_frame), *this);
+
    return CUtils::ResolveTokenString(*this, CTime(in_frame), false);
 }
 

--- a/plugins/sitoa/loader/PathTranslator.cpp
+++ b/plugins/sitoa/loader/PathTranslator.cpp
@@ -27,10 +27,11 @@ CPathString CPathString::ResolveTokens(double in_frame, CString in_extraToken)
 {
    if (!in_extraToken.IsEmpty())
    {
-      if (in_extraToken == L"[Pass]")
+      if (in_extraToken.IsEqualNoCase(L"[Pass]"))
       {
          Pass pass(Application().GetActiveProject().GetActiveScene().GetActivePass());
          *this = CStringUtilities().ReplaceString(in_extraToken, pass.GetName(), *this);
+         *this = CStringUtilities().ReplaceString(L"[pass]", pass.GetName(), *this);  // lowercase quick fix
       }
    }
    return CUtils::ResolveTokenString(*this, CTime(in_frame), false);

--- a/plugins/sitoa/renderer/RendererOptions.cpp
+++ b/plugins/sitoa/renderer/RendererOptions.cpp
@@ -188,6 +188,13 @@ void CRenderOptions::Read(const Property &in_cp)
    m_max_log_warning_msgs   = (int) ParAcc_GetValue(in_cp,  L"max_log_warning_msgs",  DBL_MAX);
    m_texture_per_file_stats = (bool)ParAcc_GetValue(in_cp, L"texture_per_file_stats", DBL_MAX);
    m_output_file_tagdir_log = ParAcc_GetValue(in_cp,       L"output_file_tagdir_log", DBL_MAX).GetAsText();
+
+   m_enable_stats           = (bool)ParAcc_GetValue(in_cp, L"enable_stats",           DBL_MAX);
+   m_stats_file             = ParAcc_GetValue(in_cp,       L"stats_file",             DBL_MAX).GetAsText();
+   m_stats_mode             = (int) ParAcc_GetValue(in_cp, L"stats_mode",             DBL_MAX);
+   m_enable_profile         = (bool)ParAcc_GetValue(in_cp, L"enable_profile",         DBL_MAX);
+   m_profile_file           = ParAcc_GetValue(in_cp,       L"profile_file",           DBL_MAX).GetAsText();
+
    m_ignore_textures        = (bool)ParAcc_GetValue(in_cp, L"ignore_textures",        DBL_MAX);
    m_ignore_shaders         = (bool)ParAcc_GetValue(in_cp, L"ignore_shaders",         DBL_MAX);
    m_ignore_atmosphere      = (bool)ParAcc_GetValue(in_cp, L"ignore_atmosphere",      DBL_MAX);
@@ -278,6 +285,8 @@ SITOA_CALLBACK CommonRenderOptions_Define(CRef& in_ctxt)
    CString defaultTexturesPath = CUtils::BuildPath(app.GetInstallationPath(siProjectPath), L"Pictures");
    CString defaultAssPath      = CUtils::BuildPath(L"[Project Path]", L"Arnold_Scenes"); // Ass Path
    CString defaultLogPath      = CUtils::BuildPath(L"[Project Path]", L"Arnold_Logs");   // Log Path
+   CString defaultStatsPath    = CUtils::BuildPath(L"[Project Path]", L"Arnold_Logs", L"arnold_stats.json");
+   CString defaultProfilePath  = CUtils::BuildPath(L"[Project Path]", L"Arnold_Logs", L"arnold_profile.json");
 
    // shaders path
    char* aux = getenv("SITOA_SHADERS_PATH");
@@ -456,6 +465,13 @@ SITOA_CALLBACK CommonRenderOptions_Define(CRef& in_ctxt)
    cpset.AddParameter(L"texture_per_file_stats", CValue::siBool,   siPersistable, L"", L"", false, CValue(), CValue(), CValue(), CValue(), p);
    cpset.AddParameter(L"output_file_tagdir_log", CValue::siString, siPersistable, L"", L"", defaultLogPath, CValue(), CValue(), CValue(), CValue(), p);
    cpset.AddParameter(L"output_file_dir_log",    CValue::siString, siPersistable, L"", L"", defaultLogPath, CValue(), CValue(), CValue(), CValue(), p);
+
+   cpset.AddParameter(L"enable_stats",           CValue::siBool,   siPersistable, L"", L"", false, CValue(), CValue(), CValue(), CValue(), p);
+   cpset.AddParameter(L"stats_file",             CValue::siString, siPersistable, L"", L"", defaultStatsPath, CValue(), CValue(), CValue(), CValue(), p);
+   cpset.AddParameter(L"stats_mode",             CValue::siInt4,   siPersistable, L"", L"", eSItoALogLevel_Warnings, CValue(), CValue(), CValue(), CValue(), p);
+   cpset.AddParameter(L"enable_profile",         CValue::siBool,   siPersistable, L"", L"", false, CValue(), CValue(), CValue(), CValue(), p);
+   cpset.AddParameter(L"profile_file",           CValue::siString, siPersistable, L"", L"", defaultProfilePath, CValue(), CValue(), CValue(), CValue(), p);
+
    cpset.AddParameter(L"ignore_textures",        CValue::siBool,   siPersistable, L"", L"", false, CValue(), CValue(), CValue(), CValue(), p);
    cpset.AddParameter(L"ignore_shaders",         CValue::siBool,   siPersistable, L"", L"", false, CValue(), CValue(), CValue(), CValue(), p);
    cpset.AddParameter(L"ignore_atmosphere",      CValue::siBool,   siPersistable, L"", L"", false, CValue(), CValue(), CValue(), CValue(), p);
@@ -1005,6 +1021,18 @@ SITOA_CALLBACK CommonRenderOptions_DefineLayout(CRef& in_ctxt)
          item.PutAttribute(siUINoLabel, true);
       layout.EndGroup();
    layout.EndGroup();
+   layout.AddGroup(L"Statistics & Profiling");
+      item = layout.AddItem(L"enable_stats", L"Output Statistics");
+      item = layout.AddItem(L"stats_file", L"Stats File", siControlFilePath);
+      item.PutAttribute(siUIFileFilter, L"JSON files (*.json)|*.json||");
+      CValueArray statsMode;
+      statsMode.Add(L"Owerwrite");   statsMode.Add((int)AI_STATS_MODE_OVERWRITE);
+      statsMode.Add(L"Append");      statsMode.Add((int)AI_STATS_MODE_APPEND);
+      item = layout.AddEnumControl(L"stats_mode", statsMode, L"Stats Mode", siControlCombo);
+      item = layout.AddItem(L"enable_profile", L"Output Profile");
+      item = layout.AddItem(L"profile_file", L"Profile File", siControlFilePath);
+      item.PutAttribute(siUIFileFilter, L"JSON files (*.json)|*.json||");
+   layout.EndGroup();
    layout.AddGroup(L"Ignore", true, 0);
       layout.AddItem(L"ignore_textures",     L"Texture Maps");
       layout.AddItem(L"ignore_shaders",      L"Shaders");
@@ -1282,7 +1310,9 @@ SITOA_CALLBACK CommonRenderOptions_PPGEvent(const CRef& in_ctxt)
 
       else if (paramName == L"enable_log_file" ||
                paramName == L"log_level"       || 
-               paramName == L"output_file_tagdir_log")
+               paramName == L"output_file_tagdir_log" ||
+               paramName == L"enable_stats" ||
+               paramName == L"enable_profile")
          DiagnosticsTabLogic(cpset);
 
       else if (paramName == L"output_file_tagdir_ass" || 
@@ -1579,6 +1609,14 @@ void DiagnosticsTabLogic(CustomProperty &in_cp)
 
    int log_level = (int)ParAcc_GetValue(in_cp, L"log_level", DBL_MAX);
    ParAcc_GetParameter(in_cp, L"texture_per_file_stats").PutCapabilityFlag(siReadOnly, log_level != eSItoALogLevel_Debug); 
+
+   // stats and profiling logic
+   bool stats = (bool)ParAcc_GetValue(in_cp, L"enable_stats", DBL_MAX);
+   ParAcc_GetParameter(in_cp, L"stats_file").PutCapabilityFlag(siReadOnly, !stats);
+   ParAcc_GetParameter(in_cp, L"stats_mode").PutCapabilityFlag(siReadOnly, !stats);
+
+   bool profile = (bool)ParAcc_GetValue(in_cp, L"enable_profile", DBL_MAX);
+   ParAcc_GetParameter(in_cp, L"profile_file").PutCapabilityFlag(siReadOnly, !profile);
 }
 
 

--- a/plugins/sitoa/renderer/RendererOptions.cpp
+++ b/plugins/sitoa/renderer/RendererOptions.cpp
@@ -290,8 +290,8 @@ SITOA_CALLBACK CommonRenderOptions_Define(CRef& in_ctxt)
    CString defaultTexturesPath = CUtils::BuildPath(app.GetInstallationPath(siProjectPath), L"Pictures");
    CString defaultAssPath      = CUtils::BuildPath(L"[Project Path]", L"Arnold_Scenes"); // Ass Path
    CString defaultLogPath      = CUtils::BuildPath(L"[Project Path]", L"Arnold_Logs");   // Log Path
-   CString defaultStatsPath    = CUtils::BuildPath(L"[Project Path]", L"Arnold_Logs", L"arnold_stats.json");
-   CString defaultProfilePath  = CUtils::BuildPath(L"[Project Path]", L"Arnold_Logs", L"arnold_profile.json");
+   CString defaultStatsPath    = CUtils::BuildPath(L"[Project Path]", L"Arnold_Logs", L"[Scene]_[Pass].[Frame].stats.json");
+   CString defaultProfilePath  = CUtils::BuildPath(L"[Project Path]", L"Arnold_Logs", L"[Scene]_[Pass].[Frame].[Host]_profile.json");
 
    // shaders path
    char* aux = getenv("SITOA_SHADERS_PATH");

--- a/plugins/sitoa/renderer/RendererOptions.cpp
+++ b/plugins/sitoa/renderer/RendererOptions.cpp
@@ -291,7 +291,7 @@ SITOA_CALLBACK CommonRenderOptions_Define(CRef& in_ctxt)
    CString defaultAssPath      = CUtils::BuildPath(L"[Project Path]", L"Arnold_Scenes"); // Ass Path
    CString defaultLogPath      = CUtils::BuildPath(L"[Project Path]", L"Arnold_Logs");   // Log Path
    CString defaultStatsPath    = CUtils::BuildPath(L"[Project Path]", L"Arnold_Logs", L"[Scene]_[Pass].[Frame].stats.json");
-   CString defaultProfilePath  = CUtils::BuildPath(L"[Project Path]", L"Arnold_Logs", L"[Scene]_[Pass].[Frame].[Host]_profile.json");
+   CString defaultProfilePath  = CUtils::BuildPath(L"[Project Path]", L"Arnold_Logs", L"[Scene]_[Pass].[Frame].profile_[Host].json");
 
    // shaders path
    char* aux = getenv("SITOA_SHADERS_PATH");

--- a/plugins/sitoa/renderer/RendererOptions.h
+++ b/plugins/sitoa/renderer/RendererOptions.h
@@ -175,6 +175,13 @@ public:
    bool         m_texture_per_file_stats;
    CString      m_output_file_tagdir_log;
    // output_file_dir_log; not read, just used to display the path
+
+   bool         m_enable_stats;
+   CString      m_stats_file;
+   int          m_stats_mode;
+   bool         m_enable_profile;
+   CString      m_profile_file;
+
    bool         m_ignore_textures;
    bool         m_ignore_shaders;
    bool         m_ignore_atmosphere;
@@ -344,6 +351,13 @@ public:
       m_max_log_warning_msgs(5),
       m_texture_per_file_stats(false),
       m_output_file_tagdir_log(CUtils::BuildPath(L"[Project Path]", L"Arnold_Logs")),
+
+      m_enable_stats(false),
+      m_stats_file(CUtils::BuildPath(L"[Project Path]", L"Arnold_Logs", L"arnold_stats.json")),
+      m_stats_mode(1),
+      m_enable_profile(false),
+      m_profile_file(CUtils::BuildPath(L"[Project Path]", L"Arnold_Logs", L"arnold_profile.json")),
+
       m_ignore_textures(false),
       m_ignore_shaders(false),
       m_ignore_atmosphere(false),

--- a/plugins/sitoa/renderer/RendererOptions.h
+++ b/plugins/sitoa/renderer/RendererOptions.h
@@ -359,10 +359,10 @@ public:
       m_output_file_tagdir_log(CUtils::BuildPath(L"[Project Path]", L"Arnold_Logs")),
 
       m_enable_stats(false),
-      m_stats_file(CUtils::BuildPath(L"[Project Path]", L"Arnold_Logs", L"arnold_stats.json")),
+      m_stats_file(CUtils::BuildPath(L"[Project Path]", L"Arnold_Logs", L"[Scene]_[Pass].[Frame].stats.json")),
       m_stats_mode(1),
       m_enable_profile(false),
-      m_profile_file(CUtils::BuildPath(L"[Project Path]", L"Arnold_Logs", L"arnold_profile.json")),
+      m_profile_file(CUtils::BuildPath(L"[Project Path]", L"Arnold_Logs", L"[Scene]_[Pass].[Frame].[Host]_profile.json")),
 
       m_ignore_textures(false),
       m_ignore_shaders(false),

--- a/plugins/sitoa/renderer/RendererOptions.h
+++ b/plugins/sitoa/renderer/RendererOptions.h
@@ -362,7 +362,7 @@ public:
       m_stats_file(CUtils::BuildPath(L"[Project Path]", L"Arnold_Logs", L"[Scene]_[Pass].[Frame].stats.json")),
       m_stats_mode(1),
       m_enable_profile(false),
-      m_profile_file(CUtils::BuildPath(L"[Project Path]", L"Arnold_Logs", L"[Scene]_[Pass].[Frame].[Host]_profile.json")),
+      m_profile_file(CUtils::BuildPath(L"[Project Path]", L"Arnold_Logs", L"[Scene]_[Pass].[Frame].profile_[Host].json")),
 
       m_ignore_textures(false),
       m_ignore_shaders(false),


### PR DESCRIPTION
This is just initial support for the new Stats and Profiling JSON outputs on the Diagnostics tab.
I would like to have some feedback on what the default filenames of these files should be, because I'm not sure in what context these are supposed to be in. Is it one stats file per frame, per scene, or per pass, etc. The filename will decide how the appending of stats will be.
@sjannuz Any thoughts / recommendations?

**FYI**
Right now the Stats feature seems broken as a simple scene with just a cube is crashing Softimage and kick with Arnold 5.2.1.0. I've reported it to AD and they have created a core ticket.
You can still try out the profile feature with no problem, but if you want to test stats, make sure it's just an empty scene.

I will hold of on this development until a new core version is released that fixes this.