### PR TITLE
Full OptiX Denoiser support

### DIFF
--- a/plugins/sitoa/common/Tools.cpp
+++ b/plugins/sitoa/common/Tools.cpp
@@ -483,6 +483,33 @@ CString CStringUtilities::GetMasterBaseNodeName(CString &in_name)
    return splits[count-1];
 }
 
+
+// Return true or false if string starts with substring
+//
+// @param in_string        The input string
+// @param in_subString     The start string
+//
+// @return true or false
+//
+bool CStringUtilities::StartsWith(CString in_string, CString in_subString)
+{
+   return (in_string.FindString(in_subString) == 0);
+}
+
+
+// Return true or false if string ends with substring
+//
+// @param in_string        The input string
+// @param in_subString     The end string
+//
+// @return true or false
+//
+bool CStringUtilities::EndsWith(CString in_string, CString in_subString)
+{
+   return (in_string.ReverseFindString(in_subString) == (in_string.Length() - in_subString.Length()));
+}
+
+
 ////////////////////////////////////////////////////
 ////////////////////////////////////////////////////
 ////////////////////////////////////////////////////

--- a/plugins/sitoa/common/Tools.h
+++ b/plugins/sitoa/common/Tools.h
@@ -346,6 +346,10 @@ public:
    CString GetSoftimageNameFromSItoAName(CString &in_nane);
    // Return the name of the master node of a ginstance or a cloned light
    CString GetMasterBaseNodeName(CString &in_name);
+   // Checks if string starts with substring
+   bool StartsWith(CString in_string, CString in_subString);
+   // Checks if string ends with substring
+   bool EndsWith(CString in_string, CString in_subString);
 
 private:
    // Build the name for an Arnold node (overload for a CString input type)

--- a/plugins/sitoa/loader/Options.cpp
+++ b/plugins/sitoa/loader/Options.cpp
@@ -490,14 +490,15 @@ bool LoadDrivers(AtNode *in_optionsNode, Pass &in_pass, double in_frame, bool in
       }
 
       // if layerName ends with "_denoise", we add a denoise filter named after the layer and then add the output
-      if (thisFb.m_layerName.ReverseFindString(L"_denoise") == (thisFb.m_layerName.Length() - CString(L"_denoise").Length()))
+      if (CStringUtilities().EndsWith(thisFb.m_layerName, L"_denoise"))
       {
          // OptiX denoise needs a separete filter for each AOV, so we create them here instad of in LoadFilters()
+         CString optixFilterName = L"sitoa_" + thisFb.m_layerName + L"_optix_filter";
          AtNode* optixFilterNode = AiNode("denoise_optix_filter");
          if (!optixFilterNode)
             continue;
-         CNodeUtilities().SetName(optixFilterNode, CString(L"sitoa_" + thisFb.m_layerName + L"_optix_filter").GetAsciiString());
-         AiArraySetStr(outputs, activeBuffer, CString(thisFb.m_layerName + L" " + thisFb.m_layerDataType + L" sitoa_" + thisFb.m_layerName + L"_optix_filter " + masterFb.m_fullName).GetAsciiString());
+         CNodeUtilities().SetName(optixFilterNode, optixFilterName.GetAsciiString());
+         AiArraySetStr(outputs, activeBuffer, CString(thisFb.m_layerName + L" " + thisFb.m_layerDataType + L" " + optixFilterName + L" " + masterFb.m_fullName).GetAsciiString());
       }
       // Adding to outputs. masterFb differs from thisFb if they are both exr and share the same filename
       else if (thisFb.m_layerDataType.IsEqualNoCase(L"RGB") || thisFb.m_layerDataType.IsEqualNoCase(L"RGBA"))

--- a/plugins/sitoa/loader/Options.cpp
+++ b/plugins/sitoa/loader/Options.cpp
@@ -496,7 +496,10 @@ bool LoadDrivers(AtNode *in_optionsNode, Pass &in_pass, double in_frame, bool in
          CString optixFilterName = L"sitoa_" + thisFb.m_layerName + L"_optix_filter";
          AtNode* optixFilterNode = AiNode("denoise_optix_filter");
          if (!optixFilterNode)
+         {
+            GetMessageQueue()->LogMsg(L"[sitoa] Couldn't create denoise_optix_filter for layer " + thisFb.m_layerName, siErrorMsg);
             continue;
+         }
          CNodeUtilities().SetName(optixFilterNode, optixFilterName.GetAsciiString());
          AiArraySetStr(outputs, activeBuffer, CString(thisFb.m_layerName + L" " + thisFb.m_layerDataType + L" " + optixFilterName + L" " + masterFb.m_fullName).GetAsciiString());
       }

--- a/plugins/sitoa/renderer/DisplayDriver.h
+++ b/plugins/sitoa/renderer/DisplayDriver.h
@@ -26,7 +26,8 @@ private:
    AtBBox2 m_data_window;    // can be negative if overscan enabled
 
 public:
-   CDisplayDriverData() : m_overscan(false)
+   CDisplayDriverData() : m_overscan(false),
+                          m_progressivePasses(1)
    {}
 
    // Initialize the driver data
@@ -44,6 +45,8 @@ public:
                                  const int in_bucket_size_x, const int in_bucket_size_y,
                                  unsigned int &out_bucket_xo, unsigned int &out_bucket_yo, 
                                  unsigned int &out_bucket_size_x, unsigned int &out_bucket_size_y);
+
+   int m_progressivePasses;
 };
 
 

--- a/plugins/sitoa/renderer/DisplayDriver.h
+++ b/plugins/sitoa/renderer/DisplayDriver.h
@@ -56,7 +56,9 @@ public:
    void ResetAreaRendered();
    // Update the render context in order to reuse the same Arnold driver
    // with another render session
-   void UpdateDisplayDriver(RendererContext& in_rendererContext, unsigned int in_displayArea, const bool in_filterColorAov, const bool in_filterNumericAov);
+   void UpdateDisplayDriver(RendererContext& in_rendererContext, unsigned int in_displayArea,
+                            const bool in_filterColorAov, const bool in_filterNumericAov,
+                            const bool in_useOptixOnMain, const bool in_onlyShowDenoise);
    // Sets the dithering
    void SetDisplayDithering(bool in_dither);
 
@@ -65,6 +67,8 @@ public:
    int   m_renderHeight;
    int   m_displayArea;
    int   m_paintedDisplayArea;
+   bool  m_useOptixOnMain;
+   bool  m_onlyShowDenoise;
 };
 
 

--- a/plugins/sitoa/renderer/RenderInstance.cpp
+++ b/plugins/sitoa/renderer/RenderInstance.cpp
@@ -1264,7 +1264,8 @@ CStatus CRenderInstance::ProcessPass()
 
    if (enableDisplayDriver)
       m_displayDriver.UpdateDisplayDriver(m_renderContext, m_renderWidth*m_renderHeight, 
-                                          GetRenderOptions()->m_filter_color_AOVs, GetRenderOptions()->m_filter_numeric_AOVs);
+                                          GetRenderOptions()->m_filter_color_AOVs, GetRenderOptions()->m_filter_numeric_AOVs,
+                                          GetRenderOptions()->m_use_optix_on_main, GetRenderOptions()->m_only_show_denoise);
  
    // Check if the render has not been aborted just before render
    if (InterruptRenderSignal())
@@ -1515,7 +1516,8 @@ CStatus CRenderInstance::ProcessRegion()
       // for these new render options (1.12), let's check their existance. Else, filterColorAov defaults to false,
       // and all the previously saved scenes render aliased
       m_displayDriver.UpdateDisplayDriver(m_renderContext, displayArea, 
-                                          GetRenderOptions()->m_filter_color_AOVs, GetRenderOptions()->m_filter_numeric_AOVs);
+                                          GetRenderOptions()->m_filter_color_AOVs, GetRenderOptions()->m_filter_numeric_AOVs,
+                                          GetRenderOptions()->m_use_optix_on_main, GetRenderOptions()->m_only_show_denoise);
 
       SetLogSettings(L"Region", m_frame);
    }

--- a/plugins/sitoa/renderer/RenderInstance.cpp
+++ b/plugins/sitoa/renderer/RenderInstance.cpp
@@ -225,6 +225,7 @@ int CRenderInstance::RenderProgressiveScene()
       aa_steps.insert(-2);
    if ((aa_max > -1) && GetRenderOptions()->m_progressive_minus1)
       aa_steps.insert(-1);
+   // if progressive rendering, ignore the 1 aa step because that is already the first step in progressive
    if (!GetRenderOptions()->m_enable_progressive_render)
    {
       if ((aa_max > 1) && GetRenderOptions()->m_progressive_plus1)

--- a/plugins/sitoa/renderer/RendererOptions.h
+++ b/plugins/sitoa/renderer/RendererOptions.h
@@ -212,6 +212,10 @@ public:
    bool m_output_lights;
    bool m_output_shaders;
 
+   // denoiser
+   bool m_use_optix_on_main;
+   bool m_only_show_denoise;
+
    //////////////////////////////////////
 
    void Read(const Property &in_cp);
@@ -382,7 +386,12 @@ public:
       m_output_geometry(false),
       m_output_cameras(false),
       m_output_lights(false),
-      m_output_shaders(false)
+      m_output_shaders(false),
+
+      // denoiser
+      m_use_optix_on_main(false),
+      m_only_show_denoise(true)
+
    {
       for (LONG i=0; i<NB_MAX_LAYERS; i++)
       {
@@ -421,6 +430,8 @@ void SubdivisionTabLogic(CustomProperty &in_cp);
 void DiagnosticsTabLogic(CustomProperty &in_cp);
 // Logic for the ass archives tab
 void AssOutputTabLogic(CustomProperty &in_cp);
+// Logic for the denoiser tab
+void DenoiserTabLogic(CustomProperty &in_cp);
 
 // Reset the default values of all the parameters
 void ResetToDefault(CustomProperty &in_cp, PPGEventContext &in_ctxt);


### PR DESCRIPTION
This took longer than expected but should conclude the Optix Denoiser support.

**Workflow**
- Settings in the Denoiser tab is for denoising Main in the display driver only!
- To render out anything to file you should add a *_denoise AOV to the framebuffer outputs.

As me and @caron discussed in #34 I've added a new Denoiser tab where I put all the OptiX Denoiser settings that affects the display driver.

![optix_denoiser](https://user-images.githubusercontent.com/23527584/48304281-784b2800-e517-11e8-91fe-922e43c5dcb7.png)
I looked at MAXtoA when I implemented it but added some more things to it.
- **Only show denoise** A setting for suppressing the non-denoised Main (in progressive) so that only the denoised output is shown. This just makes much more sense to me so i enabled it by default. See below for some info.
- Progressbar updates correctly in all cases now, whereas in MAXtoA it reaches 100% before the rendering is done.

I cleaned up the old code a bit, and moved some of the progressbar code so it runs in `driver_open` instead of in each bucket.
I added some convenience functions that I miss from python to CStringUtilites: `StartsWith` and `EndsWith`

**Only show denoise implementation details**
I spent quite a lot of time on this one. At first I tried to just skip sending the non-denoised bucket to Softimage but then nothing updates. I tried a lot of thing until I settled on a workaround where I still send the non-denoised bucket to Softimage but with a size of 1 pixel. So while most of the image retained in the display is denoised, 1 pixel of each bucket in the next progressive pass is from the non-denoised image, until it's denoised again at the end of that pass. This is barely visible at all so it should be fine.

It passes the testsuite, closes #21 and closes #48 

Oh... and let me know if you have any feedback and something should change before merging.