### PR TITLE
Add Dependency Graph

### DIFF
--- a/plugins/sitoa/loader/Options.cpp
+++ b/plugins/sitoa/loader/Options.cpp
@@ -586,10 +586,13 @@ void LoadOptionsParameters(AtNode* in_optionsNode, const Property &in_arnoldOpti
    CNodeSetter::SetInt(in_optionsNode, "GI_sss_samples",          GetRenderOptions()->m_GI_sss_samples);
    CNodeSetter::SetInt(in_optionsNode, "GI_volume_samples",       GetRenderOptions()->m_GI_volume_samples);
 
-   // only export progressive if in interactive mode but not if exporting .ass
+   // some things should only be set in interactive mode but not if exporting .ass
    CString renderType = GetRenderInstance()->GetRenderType();
    if (Application().IsInteractive() && (renderType != L"Export"))
+   {
       CNodeSetter::SetBoolean(in_optionsNode, "enable_progressive_render", GetRenderOptions()->m_enable_progressive_render);
+      CNodeSetter::SetBoolean(in_optionsNode, "enable_dependency_graph", true);
+   }
 
    CNodeSetter::SetBoolean(in_optionsNode, "enable_adaptive_sampling", GetRenderOptions()->m_enable_adaptive_sampling);
    CNodeSetter::SetInt(in_optionsNode, "AA_samples_max",               GetRenderOptions()->m_AA_samples_max);


### PR DESCRIPTION
With the lack comments on #51 I just decided that it couldn't hurt to have it in SItoA as it's already there in MtoA.
Maybe there's code in SItoA that could be removed because of this change but why bother with that :)
Hopefully this change will just lead to less use of Destroy Scene.
It's enabled all the time in interactive but not exported to .ass.