### PR TITLE
Set normal to non inspectable on bump and lambert

### DIFF
--- a/plugins/sitoa/version.cpp
+++ b/plugins/sitoa/version.cpp
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and limitations 
 
 #define SITOA_MAJOR_VERSION_NUM    5
 #define SITOA_MINOR_VERSION_NUM    2
-#define SITOA_FIX_VERSION          L"0"
+#define SITOA_FIX_VERSION          L"1"
 
 
 CString GetSItoAVersion(bool in_addPlatform)

--- a/shaders/metadata/arnold_shaders.mtd
+++ b/shaders/metadata/arnold_shaders.mtd
@@ -216,6 +216,7 @@ softmax FLOAT   1
 
 [attr normal]
 desc STRING "The shader to be evaluated after the normal perturbation has been completed. Then, the perturbed normals are restored.\nIf this method is used the bump2d node should be connected to the surface parameter of the output node and not bump."
+soft.inspectable BOOL false
 
 ##############################################################################
 [node bump3d]
@@ -239,6 +240,7 @@ softmax FLOAT 1
 
 [attr normal]
 desc STRING "The shader to be evaluated after the normal perturbation has been done is specified here. Optionally, a shader to specify the color and/or reflectance can be specified here, allowing the node to be connected to the Surface slot of the material (rather than connecting bump3d to the Bump Map slot and the other shader to the Surface slot separately). This may be useful in some situations."
+soft.inspectable BOOL false
 
 ##############################################################################
 [node cache]
@@ -1383,6 +1385,7 @@ desc STRING "Controls how opaque the shader is."
 
 [attr normal]
 desc STRING "If linked, the normal to use."
+soft.inspectable BOOL false
 
 ##############################################################################
 [node layer_float]


### PR DESCRIPTION
A user on the SItoA mailing list had messed up the bump mapping because the normal parameter was inspectable on bump2d and he accidentally changed it's values.
So I thought it's probably good to make normal not inspectable on some more shaders.
This PR hides the normal in bump2d, bump3d and lambert shader.
I also bumped version to 5.2.1 just in case but it will probably not be a new SItoA release until 5.3.0.
