### PR TITLE
Fix/strand attribute mismatch

### DIFF
--- a/plugins/sitoa/loader/ICE.cpp
+++ b/plugins/sitoa/loader/ICE.cpp
@@ -887,6 +887,7 @@ CStatus LoadSinglePointCloud(const X3DObject &in_xsiObj, double in_frame,
       {
          strandIndex = 0;
          int offset=0;
+         int nbStrandPoints;
          for (LONG pointOffset=0; pointOffset < pointCount; pointOffset+=ICE_CHUNK_SIZE)
          {
             LONG nbPoints = pointCount - pointOffset < ICE_CHUNK_SIZE ? pointCount - pointOffset : ICE_CHUNK_SIZE;
@@ -901,9 +902,10 @@ CStatus LoadSinglePointCloud(const X3DObject &in_xsiObj, double in_frame,
                // just once in one of the previous points loops
                if (iceAttributes.GetStrandPosition(pointIndex, strandPos) && (strandPos.GetCount() > 1)) 
                {
-                  iceObjects.m_strands[0].DeclareAttributes(&iceAttributes, in_frame, pointIndex, strandIndex, offset);
+                  nbStrandPoints = (int)strandPos.GetCount();
+                  iceObjects.m_strands[0].DeclareAttributes(&iceAttributes, in_frame, pointIndex, strandIndex, offset, nbStrandPoints);
                   // the index for the array to be written. So, increment it by the strand's number of points
-                  offset+= (int)iceObjects.m_strands[0].m_strands[strandIndex].m_points.size();
+                  offset+= nbStrandPoints;
                   strandIndex++;
                }
             }

--- a/plugins/sitoa/loader/ICE.h
+++ b/plugins/sitoa/loader/ICE.h
@@ -437,7 +437,7 @@ public:
    // Attach a given attributes to this node
    void    DeclareICEAttributeOnNode(LONG in_index, LONG in_dataArrayIndex, CIceAttribute* in_attribute, double in_frame, 
                                      eDeclICEAttr in_declareType = eDeclICEAttr_Constant, LONG in_count=0, LONG in_offset=0, 
-                                     int in_strandCount=0);
+                                     int in_strandCount=0, int in_nbStrandPoints=0);
    // Attach a given attributes to a polymesh node
    void    DeclareICEAttributeOnMeshNode(CIceAttribute* in_attribute, const AtArray *in_indices);
    // Attach a given attributes to a volume node
@@ -831,7 +831,7 @@ public:
    // Build all the curves stuff
    bool MakeCurve(CustomProperty in_arnoldParameters, double in_frame, CDoubleArray in_defKeys, float in_secondsPerFrame, bool in_exactMb);
    // Attach all the required attributes for a strand
-   void DeclareAttributes(CIceAttributesSet *in_attributes, double in_frame, int in_pointIndex, int in_dataArrayIndex, int in_offset);
+   void DeclareAttributes(CIceAttributesSet *in_attributes, double in_frame, int in_pointIndex, int in_dataArrayIndex, int in_offset, int nbStrandPoints);
    // Set the Arnold Parameters set 
    void SetArnoldParameters(CustomProperty in_property, double in_frame);
 };

--- a/plugins/sitoa/loader/ICEHelpers.cpp
+++ b/plugins/sitoa/loader/ICEHelpers.cpp
@@ -1904,10 +1904,11 @@ bool CIceObjectBase::SetICEAttributeAsNodeParameter(CIceAttribute *in_attr, CMat
 // @param in_count:          The size of the array to be allocated
 // @param in_offset:         Used only for varying type, ie for strands. It's the offset where to start writing data into the array
 // @param in_strandCount:    For strands only: the total number of strands
+// @param in_nbStrandPoints: For strands only: The number of points on this single strand
 //
 void CIceObjectBase::DeclareICEAttributeOnNode(LONG in_index, LONG in_dataArrayIndex, CIceAttribute *in_attr, 
                                                double in_frame, eDeclICEAttr in_declareType, LONG in_count, 
-                                               LONG in_offset, int in_strandCount)
+                                               LONG in_offset, int in_strandCount, int in_nbStrandPoints)
 {
    // check if pointers are valid
    if (m_node == NULL || in_attr == NULL || !in_attr->m_isDefined)
@@ -3971,12 +3972,13 @@ bool CIceObjectStrand::MakeCurve(CustomProperty in_arnoldParameters, double in_f
 // @param in_pointIndex:     The index of the ice point 
 // @param in_dataArrayIndex: The index of the point.
 // @param in_offset:         Where the strand points begin in the points array
+// @param in_nbStrandPoints: Number of strand points on this strand
 //
-void CIceObjectStrand::DeclareAttributes(CIceAttributesSet *in_attributes, double in_frame, int in_pointIndex, int in_dataArrayIndex, int in_offset)
+void CIceObjectStrand::DeclareAttributes(CIceAttributesSet *in_attributes, double in_frame, int in_pointIndex, int in_dataArrayIndex, int in_offset, int in_nbStrandPoints)
 {
    AttrMap::iterator attribIt;
    for (attribIt = in_attributes->m_requiredAttributesMap.begin(); attribIt != in_attributes->m_requiredAttributesMap.end(); attribIt++)
-      DeclareICEAttributeOnNode(in_pointIndex, in_dataArrayIndex, attribIt->second, in_frame, eDeclICEAttr_Varying, m_nbPoints, in_offset, this->GetNbStrands());
+      DeclareICEAttributeOnNode(in_pointIndex, in_dataArrayIndex, attribIt->second, in_frame, eDeclICEAttr_Varying, m_nbPoints, in_offset, this->GetNbStrands(), in_nbStrandPoints);
 }
 
 

--- a/plugins/sitoa/loader/ICEHelpers.cpp
+++ b/plugins/sitoa/loader/ICEHelpers.cpp
@@ -2255,6 +2255,9 @@ void CIceObjectBase::DeclareICEAttributeOnNode(LONG in_index, LONG in_dataArrayI
             {
                case siICENodeDataBool:
                {
+                  // get the subarray
+                  in_attr->m_bData2D.GetSubArray(attrIndex, in_attr->m_bData);
+                  int nbAttributeValues = in_attr->m_bData.GetCount();
                   if (in_index == 0)
                   {
                      // The first time we try to write into the array, we must also allocate it.
@@ -2263,8 +2266,7 @@ void CIceObjectBase::DeclareICEAttributeOnNode(LONG in_index, LONG in_dataArrayI
                      // so we must default to "uniform", which in the case of curves means "one data per curve strand".
                      // For instance, one could use "Set Particle Color" on a strand, to give the same color to the entire strand.
                      // In this case, the size of the array to be allocated is, of course, equal to the number of strands
-                     in_attr->m_bData2D.GetSubArray(attrIndex, in_attr->m_bData);
-                     if (in_attr->m_bData.GetCount() == 1)
+                     if (nbAttributeValues == 1)
                      {
                         if (AiNodeDeclare(m_node, in_attr->m_name.GetAsciiString(), "uniform BOOL"))
                            AiNodeSetArray(m_node, in_attr->m_name.GetAsciiString(), AiArrayAllocate(in_strandCount, 1, AI_TYPE_BOOLEAN));
@@ -2277,21 +2279,35 @@ void CIceObjectBase::DeclareICEAttributeOnNode(LONG in_index, LONG in_dataArrayI
                   }
                   AtArray * dataArray = AiNodeGetArray(m_node, in_attr->m_name.GetAsciiString());
 
-                  // get the sub array
-                  in_attr->m_bData2D.GetSubArray(attrIndex, in_attr->m_bData);
-                  if (in_attr->m_bData2D.GetCount() == 1) // the offset, so WHERE to write, is then equal to incoming strand index
+                  int nbArrayValues = nbAttributeValues;
+                  if (nbAttributeValues == 1) // the offset, so WHERE to write, is then equal to incoming strand index
                      in_offset = in_index;
+                  else
+                  {
+                     if (nbAttributeValues != in_nbStrandPoints)
+                     {
+                        nbArrayValues = in_nbStrandPoints;  // override nbArrayValues if it's mismatch so that we always set the right amount ov values to the array, Github #70
+                        GetMessageQueue()->LogMsg(L"[sitoa] Strand #" + CString(in_index) + L": " + in_attr->m_name + L" array count mismatch. ("+ in_attr->m_name + L": " + CString(nbAttributeValues) + L", StrandPosition: " + CString(in_nbStrandPoints) + L")", siWarningMsg);
+                     }
+                  }
 
-                  for (ULONG i=0; i<in_attr->m_bData.GetCount(); i++, in_offset++)
-                     AiArraySetBool(dataArray, in_offset, in_attr->GetBool(i));
+                  for (ULONG i=0; i<nbArrayValues; i++, in_offset++)
+                  {
+                     if (i < nbAttributeValues)
+                        AiArraySetBool(dataArray, in_offset, in_attr->GetBool(i));
+                     else
+                        AiArraySetBool(dataArray, in_offset, false);
+                  }
                   break;
                } // all the other cases work the same way, except for the data type
                case siICENodeDataLong:
                {
+                  // get the sub array
+                  in_attr->m_lData2D.GetSubArray(attrIndex, in_attr->m_lData);
+                  int nbAttributeValues = in_attr->m_lData.GetCount();
                   if (in_index == 0)
                   {
-                     in_attr->m_lData2D.GetSubArray(attrIndex, in_attr->m_lData);
-                     if (in_attr->m_lData.GetCount() == 1)
+                     if (nbAttributeValues == 1)
                      {
                         if (AiNodeDeclare(m_node, in_attr->m_name.GetAsciiString(), "uniform INT"))
                            AiNodeSetArray(m_node, in_attr->m_name.GetAsciiString(), AiArrayAllocate(in_strandCount, 1, AI_TYPE_INT));
@@ -2304,21 +2320,35 @@ void CIceObjectBase::DeclareICEAttributeOnNode(LONG in_index, LONG in_dataArrayI
                   }
                   AtArray * dataArray = AiNodeGetArray(m_node, in_attr->m_name.GetAsciiString());
 
-                  // get the sub array
-                  in_attr->m_lData2D.GetSubArray(attrIndex, in_attr->m_lData);
-                  if (in_attr->m_lData2D.GetCount() == 1)
+                  int nbArrayValues = nbAttributeValues;
+                  if (nbAttributeValues == 1)
                      in_offset = in_index;
+                  else
+                  {
+                     if (nbAttributeValues != in_nbStrandPoints)
+                     {
+                        nbArrayValues = in_nbStrandPoints;  // override nbArrayValues if it's mismatch so that we always set the right amount ov values to the array, Github #70
+                        GetMessageQueue()->LogMsg(L"[sitoa] Strand #" + CString(in_index) + L": " + in_attr->m_name + L" array count mismatch. ("+ in_attr->m_name + L": " + CString(nbAttributeValues) + L", StrandPosition: " + CString(in_nbStrandPoints) + L")", siWarningMsg);
+                     }
+                  }
 
-                  for (ULONG i=0; i<in_attr->m_lData.GetCount(); i++, in_offset++)
-                     AiArraySetInt(dataArray, in_offset, in_attr->GetInt(i));
+                  for (ULONG i=0; i<nbArrayValues; i++, in_offset++)
+                  {
+                     if (i < nbAttributeValues)
+                        AiArraySetInt(dataArray, in_offset, in_attr->GetInt(i));
+                     else
+                        AiArraySetInt(dataArray, in_offset, 0);
+                  }
                   break;
                }
                case siICENodeDataFloat:
                {
+                  // get the sub array
+                  in_attr->m_fData2D.GetSubArray(attrIndex, in_attr->m_fData);
+                  int nbAttributeValues = in_attr->m_fData.GetCount();
                   if (in_index == 0)
                   {
-                     in_attr->m_fData2D.GetSubArray(attrIndex, in_attr->m_fData);
-                     if (in_attr->m_fData.GetCount() == 1)
+                     if (nbAttributeValues == 1)
                      {
                         if (AiNodeDeclare(m_node, in_attr->m_name.GetAsciiString(), "uniform FLOAT"))
                            AiNodeSetArray(m_node, in_attr->m_name.GetAsciiString(), AiArrayAllocate(in_strandCount, 1, AI_TYPE_FLOAT));
@@ -2331,20 +2361,35 @@ void CIceObjectBase::DeclareICEAttributeOnNode(LONG in_index, LONG in_dataArrayI
                   }
                   AtArray * dataArray = AiNodeGetArray(m_node, in_attr->m_name.GetAsciiString());
 
-                  in_attr->m_fData2D.GetSubArray(attrIndex, in_attr->m_fData);
-                  if (in_attr->m_fData.GetCount() == 1)
+                  int nbArrayValues = nbAttributeValues;
+                  if (nbAttributeValues == 1)
                      in_offset = in_index;
+                  else
+                  {
+                     if (nbAttributeValues != in_nbStrandPoints)
+                     {
+                        nbArrayValues = in_nbStrandPoints;  // override nbArrayValues if it's mismatch so that we always set the right amount ov values to the array, Github #70
+                        GetMessageQueue()->LogMsg(L"[sitoa] Strand #" + CString(in_index) + L": " + in_attr->m_name + L" array count mismatch. ("+ in_attr->m_name + L": " + CString(nbAttributeValues) + L", StrandPosition: " + CString(in_nbStrandPoints) + L")", siWarningMsg);
+                     }
+                  }
 
-                  for (ULONG i=0; i<in_attr->m_fData.GetCount(); i++, in_offset++)
-                     AiArraySetFlt(dataArray, in_offset, in_attr->GetFloat(i));
+                  for (ULONG i=0; i<nbArrayValues; i++, in_offset++)
+                  {
+                     if (i < nbAttributeValues)
+                        AiArraySetFlt(dataArray, in_offset, in_attr->GetFloat(i));
+                     else
+                        AiArraySetFlt(dataArray, in_offset, 0.0f);
+                  }
                   break;
                }
                case siICENodeDataVector3:
                {
+                  // get the sub array
+                  in_attr->m_v3Data2D.GetSubArray(attrIndex, in_attr->m_v3Data);
+                  int nbAttributeValues = in_attr->m_v3Data.GetCount();
                   if (in_index == 0)
                   {
-                     in_attr->m_v3Data2D.GetSubArray(attrIndex, in_attr->m_v3Data);
-                     if (in_attr->m_v3Data2D.GetCount() == 1)
+                     if (nbAttributeValues == 1)
                      {
                         if (AiNodeDeclare(m_node, in_attr->m_name.GetAsciiString(), "uniform VECTOR"))
                            AiNodeSetArray(m_node, in_attr->m_name.GetAsciiString(), AiArrayAllocate(in_strandCount, 1, AI_TYPE_VECTOR));
@@ -2357,25 +2402,37 @@ void CIceObjectBase::DeclareICEAttributeOnNode(LONG in_index, LONG in_dataArrayI
                   }
                   AtArray * dataArray = AiNodeGetArray(m_node, in_attr->m_name.GetAsciiString());
 
-                  // get the sub array
-                  in_attr->m_v3Data2D.GetSubArray(attrIndex, in_attr->m_v3Data);
-                  if (in_attr->m_v3Data2D.GetCount() == 1)
+                  int nbArrayValues = nbAttributeValues;
+                  if (nbAttributeValues == 1)
                      in_offset = in_index;
+                  else
+                  {
+                     if (nbAttributeValues != in_nbStrandPoints)
+                     {
+                        nbArrayValues = in_nbStrandPoints;  // override nbArrayValues if it's mismatch so that we always set the right amount ov values to the array, Github #70
+                        GetMessageQueue()->LogMsg(L"[sitoa] Strand #" + CString(in_index) + L": " + in_attr->m_name + L" array count mismatch. ("+ in_attr->m_name + L": " + CString(nbAttributeValues) + L", StrandPosition: " + CString(in_nbStrandPoints) + L")", siWarningMsg);
+                     }
+                  }
 
                   AtVector vec;
-                  for (ULONG i=0; i<in_attr->m_v3Data.GetCount(); i++, in_offset++)
+                  for (ULONG i=0; i<nbArrayValues; i++, in_offset++)
                   {
-                     CUtilities().S2A(in_attr->GetVector3f(i), vec);
+                     if (i < nbAttributeValues)
+                        CUtilities().S2A(in_attr->GetVector3f(i), vec);
+                     else
+                        vec = AtVector(0.0f, 0.0f, 0.0f);
                      AiArraySetVec(dataArray, in_offset, vec);
                   }
                   break;
                }
                case siICENodeDataColor4:
                {
+                  // get the sub array
+                  in_attr->m_cData2D.GetSubArray(attrIndex, in_attr->m_cData);
+                  int nbAttributeValues = in_attr->m_cData.GetCount();
                   if (in_index == 0)
                   {
-                     in_attr->m_cData2D.GetSubArray(attrIndex, in_attr->m_cData);
-                     if (in_attr->m_cData.GetCount() == 1)
+                     if (nbAttributeValues == 1)
                      {
                         if (AiNodeDeclare(m_node, in_attr->m_name.GetAsciiString(), "uniform RGBA"))
                            AiNodeSetArray(m_node, in_attr->m_name.GetAsciiString(), AiArrayAllocate(in_strandCount, 1, AI_TYPE_RGBA));
@@ -2388,25 +2445,37 @@ void CIceObjectBase::DeclareICEAttributeOnNode(LONG in_index, LONG in_dataArrayI
                   }
                   AtArray * dataArray = AiNodeGetArray(m_node, in_attr->m_name.GetAsciiString());
 
-                  // get the sub array
-                  in_attr->m_cData2D.GetSubArray(attrIndex, in_attr->m_cData);
-                  if (in_attr->m_cData.GetCount() == 1)
+                  int nbArrayValues = nbAttributeValues;
+                  if (nbAttributeValues == 1)
                      in_offset = in_index;
+                  else
+                  {
+                     if (nbAttributeValues != in_nbStrandPoints)
+                     {
+                        nbArrayValues = in_nbStrandPoints;  // override nbArrayValues if it's mismatch so that we always set the right amount ov values to the array, Github #70
+                        GetMessageQueue()->LogMsg(L"[sitoa] Strand #" + CString(in_index) + L": " + in_attr->m_name + L" array count mismatch. ("+ in_attr->m_name + L": " + CString(nbAttributeValues) + L", StrandPosition: " + CString(in_nbStrandPoints) + L")", siWarningMsg);
+                     }
+                  }
 
                   AtRGBA rgba;
-                  for (ULONG i=0; i<in_attr->m_cData.GetCount(); i++, in_offset++)
+                  for (ULONG i=0; i<nbArrayValues; i++, in_offset++)
                   {
-                     CUtilities().S2A(in_attr->GetColor4f(i), rgba);
+                     if (i < nbAttributeValues)
+                        CUtilities().S2A(in_attr->GetColor4f(i), rgba);
+                     else
+                        rgba = AI_RGBA_ZERO;
                      AiArraySetRGBA(dataArray, in_offset, rgba);
                   }
                   break;
                }
                case siICENodeDataMatrix44:
                {
+                  // get the sub array
+                  in_attr->m_m4Data2D.GetSubArray(attrIndex, in_attr->m_m4Data);
+                  int nbAttributeValues = in_attr->m_m4Data.GetCount();
                   if (in_index == 0)
                   {
-                     in_attr->m_m4Data2D.GetSubArray(attrIndex, in_attr->m_m4Data);
-                     if (in_attr->m_m4Data2D.GetCount() == 1)
+                     if (nbAttributeValues == 1)
                      {
                         if (AiNodeDeclare(m_node, in_attr->m_name.GetAsciiString(), "uniform MATRIX"))
                            AiNodeSetArray(m_node, in_attr->m_name.GetAsciiString(), AiArrayAllocate(in_strandCount, 1, AI_TYPE_MATRIX));
@@ -2419,15 +2488,25 @@ void CIceObjectBase::DeclareICEAttributeOnNode(LONG in_index, LONG in_dataArrayI
                   }
                   AtArray * dataArray = AiNodeGetArray(m_node, in_attr->m_name.GetAsciiString());
 
-                  // get the sub array
-                  in_attr->m_m4Data2D.GetSubArray(attrIndex, in_attr->m_m4Data);
-                  if (in_attr->m_m4Data2D.GetCount() == 1)
+                  int nbArrayValues = nbAttributeValues;
+                  if (nbAttributeValues == 1)
                      in_offset = in_index;
+                  else
+                  {
+                     if (nbAttributeValues != in_nbStrandPoints)
+                     {
+                        nbArrayValues = in_nbStrandPoints;  // override nbArrayValues if it's mismatch so that we always set the right amount ov values to the array, Github #70
+                        GetMessageQueue()->LogMsg(L"[sitoa] Strand #" + CString(in_index) + L": " + in_attr->m_name + L" array count mismatch. ("+ in_attr->m_name + L": " + CString(nbAttributeValues) + L", StrandPosition: " + CString(in_nbStrandPoints) + L")", siWarningMsg);
+                     }
+                  }
 
                   AtMatrix matrix;
-                  for (ULONG i=0; i<in_attr->m_m4Data.GetCount(); i++, in_offset++)
+                  for (ULONG i=0; i<nbArrayValues; i++, in_offset++)
                   {
-                     CUtilities().S2A(in_attr->GetMatrix4f(i), matrix);
+                     if (i < nbAttributeValues)
+                        CUtilities().S2A(in_attr->GetMatrix4f(i), matrix);
+                     else
+                        matrix = AiM4Identity();
                      AiArraySetMtx(dataArray, in_offset, matrix);
                   }
                   break;


### PR DESCRIPTION
I added checks to make sure we always export the same number of varying ICE strand attributes as the number of points we have on the strand.
I also added a warning if there's mismatch between attributes and position counts so the user know when something isn't right and can fix it in the scene.
If, the number if values are less than the number of points, the following will be added in place of the missing values:
- bool will be false
- float, int, vector and color will all be 0
- matrix will be identity

I didn't update test_0025 because that passes now with this fix, but with warnings about the mismatch.

This fixes #70