### PR TITLE
Better new scene default

### DIFF
--- a/plugins/helpers/ArnoldScenePreferences.js
+++ b/plugins/helpers/ArnoldScenePreferences.js
@@ -76,6 +76,18 @@ function SetSceneForArnold()
             DisconnectAndDeleteOrUnnestShaders("light.light.soft_light", "light.light");
          }
       
+         // Modify Scene_Material to use standard_surface
+         var sceneMaterial = Dictionary.GetObject("Sources.Materials.DefaultLib.Scene_Material");
+         var currentShader = sceneMaterial.Surface.Source.Parent;
+         if (currentShader.Name == "Phong")
+         {
+            var shader = CreateShaderFromProgID("Arnold.standard_surface.1.0", sceneMaterial, null);
+            var closure = CreateShaderFromProgID("Arnold.closure.1.0", sceneMaterial, null);
+            SIConnectShaderToCnxPoint(shader, closure.closure, false);
+            SIConnectShaderToCnxPoint(closure, sceneMaterial.Surface, false);
+            DisconnectAndDeleteOrUnnestShaders(sceneMaterial + ".Phong", sceneMaterial);
+         }
+
          // Use pass render options as the view render options are not supported for the moment
          SetValue("Views.ViewA.RenderRegion.UsePassOptions,Views.ViewB.RenderRegion.UsePassOptions,"+
                   "Views.ViewC.RenderRegion.UsePassOptions,Views.ViewD.RenderRegion.UsePassOptions",

--- a/plugins/helpers/ArnoldScenePreferences.js
+++ b/plugins/helpers/ArnoldScenePreferences.js
@@ -74,7 +74,7 @@ function SetSceneForArnold()
             SIConnectShaderToCnxPoint(shader, light.ActivePrimitive + ".LightShader", true);
 
             DisconnectAndDeleteOrUnnestShaders("light.light.soft_light", "light.light");
-            SetValue(shader + ".intensity", 3.5, "");
+            SetValue(shader + ".intensity", 4.0, "");
             SetValue(shader + ".angle", 0.53, "");
          }
       

--- a/plugins/helpers/ArnoldScenePreferences.js
+++ b/plugins/helpers/ArnoldScenePreferences.js
@@ -74,6 +74,8 @@ function SetSceneForArnold()
             SIConnectShaderToCnxPoint(shader, light.ActivePrimitive + ".LightShader", true);
 
             DisconnectAndDeleteOrUnnestShaders("light.light.soft_light", "light.light");
+            SetValue(shader + ".intensity", 3.5, "");
+            SetValue(shader + ".angle", 0.53, "");
          }
       
          // Modify Scene_Material to use standard_surface


### PR DESCRIPTION
It has always bugged me that standard_surface isn't the default shader on Scene_Material in new Arnold scenes since Phong was not supported anymore.
One other thing that bugged me is that the default light is too dark at intensity 1. A value of PI (3.14) would equal a light output of 1. I choose a new default value a little higher than that because that is a more realistic value to use with a good view LUT. I also added a little soft shadow equal to the size of the sun.
So in conclusion, this PR does these changes on new scenes:
- Replaces Phong with `standard_surface` on Scene_Material.
- Set `distant_light.intensity` to 4
- Set `distant_light.angle` to 0.53