### PR TITLE
Patch AdLM with abuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,12 @@ To build and install the plugins and the shaders in `TARGET_WORKGROUP_PATH`
 abuild install
 ```
 
+To patch AdLM (#74), run:
+
+```
+abuild patch
+```
+
 To generate a Softimage add-on, run:
 
 ```

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ TARGET_WORKGROUP_PATH  = r'./Softimage_2015/Addons/SItoA'
 WARN_LEVEL = 'strict'
 MODE       = 'debug'
 SHOW_CMDS  = True
+
+PATCH_ADLM = True
 ```
 
 Default configuration files for Windows and Linux reside in `config`. If you

--- a/README.md
+++ b/README.md
@@ -108,12 +108,6 @@ To build and install the plugins and the shaders in `TARGET_WORKGROUP_PATH`
 abuild install
 ```
 
-To patch AdLM (#74), run:
-
-```
-abuild patch
-```
-
 To generate a Softimage add-on, run:
 
 ```

--- a/SConstruct
+++ b/SConstruct
@@ -20,7 +20,7 @@ import SCons
 def make_package(target, source, env):
    package_name = str(target[0]) + ".xsiaddon"
    zip_name = str(target[0])
-   base_pkg_dir = os.path.join('dist', 'package_temp' + get_softimage_version(env['XSISDK_ROOT']));
+   base_pkg_dir = os.path.join('dist', 'package_temp' + get_softimage_version(env['XSISDK_ROOT']))
    
    # First we make sure the temp directory doesn't exist
    #if os.path.exists(base_pkg_dir):

--- a/config/custom_windows.py
+++ b/config/custom_windows.py
@@ -16,3 +16,5 @@ TARGET_WORKGROUP_PATH  = r'./Softimage_2015/Addons/SItoA'
 WARN_LEVEL = 'strict'
 MODE       = 'opt'
 SHOW_CMDS  = True
+
+PATCH_ADLM = True


### PR DESCRIPTION
Since I've never got an answer if #74 is ever going to be fixed I made a patch for it with abuild.
It renames `adlmint.dll` to `adlmin2.dll` and patches `AdClmHub_1.dll` to point to the renamed file.
Run the command below to apply the patch.
Only tested on Windows for now and I actually don't know if it's even needed on Linux.
```
abuild patch
```