### PR TITLE
Arnold 6.0.2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ under an Apache 2.0 open source license.
 #### Requirements
 
 * Softimage 2015 SP1
-* Arnold 6.0.1.0 or newer
+* Arnold 6.0.2.0 or newer
 * Python 2.6 or newer
 * Visual Studio 2015 (Windows)
 * GCC 4.2.4 (Linux)
@@ -65,7 +65,7 @@ VS_HOME             = r'C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC'
 WINDOWS_KIT         = r'C:/Program Files (x86)/Windows Kits/8.0'
 
 XSISDK_ROOT         = r'C:/Program Files/Autodesk/Softimage 2015/XSISDK'
-ARNOLD_HOME         = r'C:/SolidAngle/Arnold-6.0.1.0/win64'
+ARNOLD_HOME         = r'C:/SolidAngle/Arnold-6.0.2.0/win64'
 
 TARGET_WORKGROUP_PATH  = r'./Softimage_2015/Addons/SItoA'
 

--- a/SConstruct
+++ b/SConstruct
@@ -407,7 +407,7 @@ PACKAGE_FILES = [
 [os.path.join(ARNOLD_BINARIES, '*%s.*' % get_library_extension()),         os.path.join(addon_path, bin_path)],
 [os.path.join(ARNOLD_BINARIES, '*.pit'),                                   os.path.join(addon_path, bin_path)],
 [os.path.join(ARNOLD_BINARIES, '*.png'),                                   os.path.join(addon_path, bin_path)],
-[os.path.join(ARNOLD_PLUGINS, '*'),                                        os.path.join(addon_path, bin_path, '..', 'plugins')],
+[os.path.join(ARNOLD_PLUGINS),                                             os.path.join(addon_path, bin_path, '..', 'plugins')],
 [os.path.join('plugins', 'helpers', '*.js'),                               os.path.join(addon_path, plugins_path)],
 [os.path.join('plugins', 'helpers', '*.py'),                               os.path.join(addon_path, plugins_path)],
 [os.path.join('plugins', 'helpers', 'Pictures', '*.bmp'),                  os.path.join(addon_path, pictures_path)],

--- a/config/custom_linux.py
+++ b/config/custom_linux.py
@@ -6,7 +6,7 @@
 SHCXX       = r'/usr/bin/gcc-4.2.4/bin/gcc-4.2.4'
 
 XSISDK_ROOT = r'/usr/Softimage/Softimage_2015/XSISDK'
-ARNOLD_HOME = r'/usr/SolidAngle/Arnold-6.0.1.0/linux'
+ARNOLD_HOME = r'/usr/SolidAngle/Arnold-6.0.2.0/linux'
 
 TARGET_WORKGROUP_PATH = './Softimage_2015/Addons/SItoA'
 

--- a/config/custom_windows.py
+++ b/config/custom_windows.py
@@ -9,7 +9,7 @@ VS_HOME             = r'C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC'
 WINDOWS_KIT         = r'C:/Program Files (x86)/Windows Kits/8.0'
 
 XSISDK_ROOT         = r'C:/Program Files/Autodesk/Softimage 2015/XSISDK'
-ARNOLD_HOME         = r'C:/SolidAngle/Arnold-6.0.1.0/win64'
+ARNOLD_HOME         = r'C:/SolidAngle/Arnold-6.0.2.0/win64'
 
 TARGET_WORKGROUP_PATH  = r'./Softimage_2015/Addons/SItoA'
 

--- a/plugins/helpers/ArnoldProperties.js
+++ b/plugins/helpers/ArnoldProperties.js
@@ -1280,6 +1280,10 @@ function arnold_procedural_Define(io_Context)
    p = customProperty.AddParameter2("frame", siInt4, 1, -1000000, 1000000, 1, 100, siClassifAppearance, siPersistable|siAnimatable);
    p.enable(false);
 
+   p = customProperty.AddParameter2("override_nodes", siBool, 0, 0, 1, 0, 1, 0, siPersistable|siAnimatable);
+   p = customProperty.AddParameter2("auto_instancing", siBool, 1, 0, 1, 0, 1, 0, siPersistable|siAnimatable);
+   p = customProperty.AddParameter2("namespace", siString, "", "", "", "", "", 0, siPersistable|siAnimatable);
+
    // new (2.2) viewer parameters at object's level
    p = customProperty.AddParameter2("mode", siInt4, 0, 0, 2, 0, 2, siClassifAppearance, siPersistable|siAnimatable);
    p = customProperty.AddParameter2("randomColors", siBool, 0, 0, 1, 0, 1, 0, siPersistable|siAnimatable);	
@@ -1321,6 +1325,10 @@ function arnold_procedural_DefineLayout(io_Context)
       xsiItem = xsiLayout.AddItem("frame", "Frame");
       xsiItem.WidthPercentage = 60;
    xsiLayout.EndRow()
+
+   xsiItem = xsiLayout.AddItem("override_nodes", "Override Nodes");
+   xsiItem = xsiLayout.AddItem("auto_instancing", "Auto Instancing");
+   xsiItem = xsiLayout.AddItem("namespace", "Namespace");
 
    UserDataLayout(xsiLayout, true);
 

--- a/plugins/helpers/ArnoldProperties.js
+++ b/plugins/helpers/ArnoldProperties.js
@@ -1321,9 +1321,11 @@ function arnold_procedural_DefineLayout(io_Context)
 
    xsiLayout.AddRow()
       xsiItem = xsiLayout.AddItem("overrideFrame", "Override Frame");
-      xsiItem.WidthPercentage = 40;
+      xsiItem.WidthPercentage = 50;
       xsiItem = xsiLayout.AddItem("frame", "Frame");
-      xsiItem.WidthPercentage = 60;
+      xsiItem.WidthPercentage = 50;
+      xsiItem.SetAttribute(siUILabelMinPixels, 50);
+      xsiItem.SetAttribute(siUILabelPercentage, 10);
    xsiLayout.EndRow()
 
    xsiItem = xsiLayout.AddItem("override_nodes", "Override Nodes");

--- a/plugins/helpers/ArnoldProperties.js
+++ b/plugins/helpers/ArnoldProperties.js
@@ -831,6 +831,12 @@ function arnold_camera_options_Define(io_Context)
 
    prop.AddParameter2("exposure", siFloat, 0, -10000, 10000, -5, 5, 0, siPersistable|siAnimatable);
 
+   // perspective
+   prop.AddParameter2("persp_radial_distortion", siFloat, 0, -10000, 10000, -0.2, 2.0, 0, siPersistable|siAnimatable);
+   prop.AddParameter2("persp_radial_distortion_type", siString, "cubic", siPersistable|siAnimatable);
+   prop.AddParameter2("persp_lens_tilt_angle_x", siFloat, 0, -10000, 10000, -45, 45, 0, siPersistable|siAnimatable);
+   prop.AddParameter2("persp_lens_tilt_angle_y", siFloat, 0, -10000, 10000, -45, 45, 0, siPersistable|siAnimatable);
+
    // cylindrical
    prop.AddParameter2("cyl_horizontal_fov", siFloat, 60, 0.001, 360, 0.001, 360, 0, siPersistable|siAnimatable);
    prop.AddParameter2("cyl_vertical_fov", siFloat, 90, 0.001, 180, 0.001, 180, 0, siPersistable|siAnimatable);
@@ -902,6 +908,24 @@ function arnold_camera_options_DefineLayout(io_Context)
    layout.AddGroup("Exposure");
       item = layout.AddItem("exposure", "")
       item.SetAttribute(siUINoLabel, true);
+   layout.EndGroup();
+
+   layout.AddGroup("Perspective");
+      item = layout.AddItem("persp_radial_distortion", "Radial Distortion");
+      item.SetAttribute(siUILabelMinPixels, 130);
+      item.SetAttribute(siUILabelPercentage, 50);
+      item = layout.AddEnumControl("persp_radial_distortion_type", Array("Cubic",         "cubic",
+                                                                         "Cubic Inverse", "cubic_inverse"), "Radial Distortion Type", siControlCombo);
+      item.SetAttribute(siUILabelMinPixels, 130);
+      item.SetAttribute(siUILabelPercentage, 50);
+      layout.AddGroup("Lens Tilt Angle")
+         layout.AddRow();
+            item = layout.AddItem("persp_lens_tilt_angle_x", "X");
+            item.SetAttribute(siUINoLabel, true);
+            item = layout.AddItem("persp_lens_tilt_angle_y", "Y");
+            item.SetAttribute(siUINoLabel, true);
+         layout.EndRow();
+      layout.EndGroup();
    layout.EndGroup();
 
    layout.AddGroup("Cylindrical");

--- a/plugins/helpers/ArnoldProperties.js
+++ b/plugins/helpers/ArnoldProperties.js
@@ -1078,6 +1078,11 @@ function arnold_camera_options_camera_type_OnChanged()
 {
    var cameraType = PPG.camera_type.Value;
 
+   PPG.persp_radial_distortion.Enable(cameraType == "persp_camera");
+   PPG.persp_radial_distortion_type.Enable(cameraType == "persp_camera");
+   PPG.persp_lens_tilt_angle_x.Enable(cameraType == "persp_camera");
+   PPG.persp_lens_tilt_angle_y.Enable(cameraType == "persp_camera");
+
    PPG.cyl_horizontal_fov.Enable(cameraType == "cyl_camera");
    PPG.cyl_vertical_fov.Enable(cameraType == "cyl_camera");
    PPG.cyl_projective.Enable(cameraType == "cyl_camera");

--- a/plugins/helpers/ArnoldShaderDef.js
+++ b/plugins/helpers/ArnoldShaderDef.js
@@ -154,6 +154,7 @@ function XSILoadPlugin( in_reg )
    in_reg.RegisterShader("operator", 1, 0);
    in_reg.RegisterShader("set_parameter", 1, 0);
    in_reg.RegisterShader("set_transform", 1, 0);
+   in_reg.RegisterShader("string_replace", 1, 0);
    in_reg.RegisterShader("switch_operator", 1, 0);
 
    // in_reg.Help = "https://support.solidangle.com/display/A5SItoAUG/Shaders";
@@ -427,6 +428,8 @@ function Arnold_set_parameter_1_0_DefineInfo(in_ctxt) { return true; }
 //function Arnold_set_parameter_1_0_Define(in_ctxt) { return true; }
 function Arnold_set_transform_1_0_DefineInfo(in_ctxt) { return true; }
 function Arnold_set_transform_1_0_Define(in_ctxt) { return true; }
+function Arnold_string_replace_1_0_DefineInfo(in_ctxt) { return true; }
+function Arnold_string_replace_1_0_Define(in_ctxt) { return true; }
 function Arnold_switch_operator_1_0_DefineInfo(in_ctxt) { return true; }
 function Arnold_switch_operator_1_0_Define(in_ctxt) { return true; }
 

--- a/plugins/metadata/arnold_operators.mtd
+++ b/plugins/metadata/arnold_operators.mtd
@@ -82,6 +82,12 @@ linkable BOOL false
 linkable BOOL false
 
 ###########################################################################
+[node string_replace]
+
+[attr enable]
+linkable BOOL false
+
+###########################################################################
 [node switch_operator]
 
 [attr enable]

--- a/plugins/sitoa/common/Tools.h
+++ b/plugins/sitoa/common/Tools.h
@@ -51,6 +51,7 @@ namespace ATSTRING
    const AtString ginstance("ginstance");
    const AtString image("image");
    const AtString mesh_light("mesh_light");
+   const AtString persp_camera("persp_camera");
    const AtString photometric_light("photometric_light");
    const AtString physical_sky("physical_sky");
    const AtString points("points");

--- a/plugins/sitoa/loader/Procedurals.cpp
+++ b/plugins/sitoa/loader/Procedurals.cpp
@@ -235,6 +235,10 @@ CStatus LoadSingleProcedural(const X3DObject &in_xsiObj, double in_frame, CRefAr
    CNodeUtilities().SetName(procNode, name);
    CNodeSetter::SetString(procNode, "filename", filename.GetAsciiString());
 
+   CNodeSetter::SetBoolean(procNode, "override_nodes", (bool)ParAcc_GetValue(proceduralInfo, L"override_nodes", in_frame));
+   CNodeSetter::SetBoolean(procNode, "auto_instancing", (bool)ParAcc_GetValue(proceduralInfo, L"auto_instancing", in_frame));
+   CNodeSetter::SetString(procNode, "namespace", ((CString)ParAcc_GetValue(proceduralInfo, L"namespace", in_frame)).GetAsciiString());
+
    // Getting Motion Blur Data
    CDoubleArray keyFramesTransform;
    CDoubleArray keyFramesDeform;

--- a/plugins/sitoa/loader/Properties.cpp
+++ b/plugins/sitoa/loader/Properties.cpp
@@ -532,7 +532,24 @@ void LoadCameraOptions(const Camera &in_xsiCamera, AtNode* in_node, const Proper
 
    CNodeSetter::SetFloat(in_node, "exposure", (float)ParAcc_GetValue(in_property, L"exposure", in_frame));
 
-   if (cameraType == L"fisheye_camera")
+   if (cameraType == L"persp_camera")
+   {
+      CNodeSetter::SetFloat(in_node, "radial_distortion", (float)ParAcc_GetValue(in_property, L"persp_radial_distortion", in_frame));
+      CString s = ((CString)ParAcc_GetValue(in_property, L"persp_radial_distortion_type", in_frame));
+      CNodeSetter::SetString(in_node, "radial_distortion_type", s.GetAsciiString());
+
+      AtArray* lens_tilt_angles = AiArrayAllocate(1, (uint8_t)nbTransfKeys, AI_TYPE_VECTOR2);
+      for (LONG ikey=0; ikey<nbTransfKeys; ikey++)
+      {
+         double frame = transfKeys[ikey];
+         float lens_tilt_angle_x = (float)ParAcc_GetValue(in_property, L"persp_lens_tilt_angle_x", frame);
+         float lens_tilt_angle_y = (float)ParAcc_GetValue(in_property, L"persp_lens_tilt_angle_y", frame);
+         AtVector2 lens_tilt_angle = AtVector2(lens_tilt_angle_x, lens_tilt_angle_y);
+         AiArraySetVec2(lens_tilt_angles, ikey, AtVector2(lens_tilt_angle_x, lens_tilt_angle_y));
+      }
+      AiNodeSetArray(in_node, "lens_tilt_angle", lens_tilt_angles);
+   }
+   else if (cameraType == L"fisheye_camera")
       CNodeSetter::SetBoolean(in_node, "autocrop", (bool)ParAcc_GetValue(in_property, L"fisheye_autocrop", in_frame));
    else if (cameraType == L"cyl_camera")
    {

--- a/plugins/sitoa/version.cpp
+++ b/plugins/sitoa/version.cpp
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and limitations 
 
 #define SITOA_MAJOR_VERSION_NUM    6
 #define SITOA_MINOR_VERSION_NUM    0
-#define SITOA_FIX_VERSION          L"0"
+#define SITOA_FIX_VERSION          L"1"
 
 
 CString GetSItoAVersion(bool in_addPlatform)


### PR DESCRIPTION
Some new stuff in this one:
* New operator `string_replace`
* Added `radial_distortion` and `lens_tilt` to Arnold Camera
* Added `override_nodes`, `auto_instancing` and `namespace` to Arnold Procedural

And some changes / enhancements:
* Optical Shift is now using `lens_shift` instead of `screen_window` on `persp_camera`s

Passes test suite with no problems.